### PR TITLE
Suggest using SyncReadMem over SeqMem in Chisel3 migration guide.

### DIFF
--- a/docs/src/main/tut/chisel3/chisel3-vs-chisel2.md
+++ b/docs/src/main/tut/chisel3/chisel3-vs-chisel2.md
@@ -78,8 +78,9 @@ for instructions on preparing your Chisel2 designs for Chisel3.
 *  the con and alt inputs to a Mux must be type-compatible - both signed or both unsigned,
 *  bulk-connection to a node that has been procedurally assigned-to is illegal,
 *  `!=` is deprecated, use `=/=` instead,
-*  use `SeqMem(...)` instead of `Mem(..., seqRead)`,
-*  use `SeqMem(n:Int, out: => T)` instead of `SeqMem(out: => T, n:Int)`,
+*  use `SyncReadMem(...)` instead of `Mem(..., seqRead)`,
+*  use `SyncReadMem(n:Int, out: => T)` instead of `SyncReadMem(out: => T, n:Int)`,
+*  use `SyncReadMem(...)` instead of `SeqMem(...)`,
 *  use `Mem(n:Int, t:T)` instead of `Mem(out:T, n:Int)`,
 *  use `Vec(n:Int, gen: => T)` instead of `Vec(gen: => T, n:Int)`,
 *  module io's must be wrapped in `IO()`.


### PR DESCRIPTION
I believe that this is the currently recommended usage, so I've replaced the instances of `SeqMem` with `SyncReadMem` in the migration guide. I also added a line that explicitly suggests using `SyncReadMem` over `SeqMem`. Let me know if this requires any changes, or feel free to make any edits to this PR yourself.