### PR TITLE
Recognize Website Contributions in Acknowledgments

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -124,7 +124,8 @@ lazy val contributors =
                GitHubRepository("freechipsproject", "firrtl"),
                GitHubRepository("freechipsproject", "chisel-testers"),
                GitHubRepository("freechipsproject", "treadle"),
-               GitHubRepository("freechipsproject", "diagrammer") )
+               GitHubRepository("freechipsproject", "diagrammer"),
+               GitHubRepository("freechipsproject", "www.chisel-lang.org") )
             .map(Contributors.contributors)
             .reduce(_ ++ _)
             .distinct


### PR DESCRIPTION
Adds contributions to this website to the contributors list in the acknowledgments tab. This catches contributions like #12.