### PR TITLE
Add documentation from SNAPSHOT releases

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,11 +16,11 @@ define getTags
 	$(shell cd $(1) && git tag | grep "^v\([0-9]\+\.\)\{2\}[0-9]\+$$")
 endef
 
-firrtlTags = $(call getTags,firrtl)
-chiselTags = $(call getTags,chisel3)
-testersTags = $(call getTags,chisel-testers)
-treadleTags = $(call getTags,treadle)
-diagrammerTags = $(call getTags,diagrammer)
+firrtlTags = $(call getTags,firrtl) master
+chiselTags = $(call getTags,chisel3) master
+testersTags = $(call getTags,chisel-testers) master
+treadleTags = $(call getTags,treadle) master
+diagrammerTags = $(call getTags,diagrammer) master
 
 api-copy = \
 	docs/target/site/api/chisel3/latest/index.html \

--- a/Makefile
+++ b/Makefile
@@ -13,14 +13,17 @@ chisel-src = $(shell find chisel3/ chisel-testers/ -name *.scala)
 # Get all semantic version tags for a git project in a given directory
 # Usage: $(call getTags,foo)
 define getTags
-	$(shell cd $(1) && git tag | grep "^v\([0-9]\+\.\)\{2\}[0-9]\+$$")
+	$(shell cd $(1) && git tag | grep "^v[0-9]\+\(\.[0-9]\+\)*$$")
+endef
+define getSnapshot
+	$(shell cd $(1) && git tag | grep "^v.\+-SNAPSHOT$$" | sort -nr | head -n1)
 endef
 
-firrtlTags = $(call getTags,firrtl) master
-chiselTags = $(call getTags,chisel3) master
-testersTags = $(call getTags,chisel-testers) master
-treadleTags = $(call getTags,treadle) master
-diagrammerTags = $(call getTags,diagrammer) master
+firrtlTags = $(call getTags,firrtl) $(call getSnapshot,firrtl)
+chiselTags = $(call getTags,chisel3) $(call getSnapshot,chisel3)
+testersTags = $(call getTags,chisel-testers) $(call getSnapshot,chisel-testers)
+treadleTags = $(call getTags,treadle) $(call getSnapshot,treadle)
+diagrammerTags = $(call getTags,diagrammer) $(call getSnapshot,diagrammer)
 
 api-copy = \
 	docs/target/site/api/chisel3/latest/index.html \
@@ -133,14 +136,19 @@ $(apis)/diagrammer/%/index.html: $(subprojects)/diagrammer/%/target/scala-$(scal
 # Copy *old* API of subprojects from API directory into website
 docs/target/site/api/chisel3/%/index.html: $(apis)/chisel3/%/index.html | docs/target/site/api/chisel3/%/
 	cp -r $(dir $<)* $(dir $@)
+	if [[ $* == *-SNAPSHOT ]]; then (cd $(dir $@).. && ln -sf $* SNAPSHOT); fi
 docs/target/site/api/firrtl/%/index.html: $(apis)/firrtl/%/index.html | docs/target/site/api/firrtl/%/
 	cp -r $(dir $<)* $(dir $@)
+	if [[ $* == *-SNAPSHOT ]]; then (cd $(dir $@).. && ln -sf $* SNAPSHOT); fi
 docs/target/site/api/chisel-testers/%/index.html: $(apis)/chisel-testers/%/index.html | docs/target/site/api/chisel-testers/%/
 	cp -r $(dir $<)* $(dir $@)
+	if [[ $* == *-SNAPSHOT ]]; then (cd $(dir $@).. && ln -sf $* SNAPSHOT); fi
 docs/target/site/api/treadle/%/index.html: $(apis)/treadle/%/index.html | docs/target/site/api/treadle/%/
 	cp -r $(dir $<)* $(dir $@)
+	if [[ $* == *-SNAPSHOT ]]; then (cd $(dir $@).. && ln -sf $* SNAPSHOT); fi
 docs/target/site/api/diagrammer/%/index.html: $(apis)/diagrammer/%/index.html | docs/target/site/api/diagrammer/%/
 	cp -r $(dir $<)* $(dir $@)
+	if [[ $* == *-SNAPSHOT ]]; then (cd $(dir $@).. && ln -sf $* SNAPSHOT); fi
 
 # Utilities to either fetch submodules or create directories
 %/.git:

--- a/docs/src/main/resources/microsite/data/menu.yml
+++ b/docs/src/main/resources/microsite/data/menu.yml
@@ -118,6 +118,8 @@ options:
     url: api/chisel3/latest/index.html
     menu_type: chisel3
     nested_options:
+      - title: master
+        url: api/chisel3/master/index.html
       - title: v3.1.8
         url: api/chisel3/v3.1.8/index.html
       - title: v3.1.7
@@ -151,6 +153,8 @@ options:
     url: api/chisel-testers/latest/index.html
     menu_type: chisel-testers
     nested_options:
+      - title: master
+        url: api/chisel-testers/master/index.html
       - title: v1.2.10
         url: api/chisel-testers/v1.2.10/index.html
       - title: v1.2.9
@@ -188,6 +192,8 @@ options:
     url: api/firrtl/latest/index.html
     menu_type: firrtl
     nested_options:
+      - title: master
+        url: api/firrtl/master/index.html
       - title: v1.1.7
         url: api/firrtl/v1.1.7/index.html
       - title: v1.1.6
@@ -219,18 +225,20 @@ options:
     url: api/treadle/latest/index.html
     menu_type: treadle
     nested_options:
-    - title: v1.0.5
-      url: api/treadle/v1.0.5/index.html
-    - title: v1.0.4
-      url: api/treadle/v1.0.4/index.html
-    - title: v1.0.3
-      url: api/treadle/v1.0.3/index.html
-    - title: v1.0.2
-      url: api/treadle/v1.0.2/index.html
-    - title: v1.0.1
-      url: api/treadle/v1.0.1/index.html
-    - title: v1.0.0
-      url: api/treadle/v1.0.0/index.html
+      - title: master
+        url: api/treadle/master/index.html
+      - title: v1.0.5
+        url: api/treadle/v1.0.5/index.html
+      - title: v1.0.4
+        url: api/treadle/v1.0.4/index.html
+      - title: v1.0.3
+        url: api/treadle/v1.0.3/index.html
+      - title: v1.0.2
+        url: api/treadle/v1.0.2/index.html
+      - title: v1.0.1
+        url: api/treadle/v1.0.1/index.html
+      - title: v1.0.0
+        url: api/treadle/v1.0.0/index.html
 
   # Diagrammer Site
   - title: Diagrammer
@@ -240,9 +248,11 @@ options:
     url: api/diagrammer/latest/index.html
     menu_type: diagrammer
     nested_options:
-    - title: v1.0.2
-      url: api/diagrammer/v1.0.2/index.html
-    - title: v1.0.1
-      url: api/diagrammer/v1.0.1/index.html
-    - title: v1.0.0
-      url: api/diagrammer/v1.0.0/index.html
+      - title: master
+        url: api/diagrammer/master/index.html
+      - title: v1.0.2
+        url: api/diagrammer/v1.0.2/index.html
+      - title: v1.0.1
+        url: api/diagrammer/v1.0.1/index.html
+      - title: v1.0.0
+        url: api/diagrammer/v1.0.0/index.html

--- a/docs/src/main/resources/microsite/data/menu.yml
+++ b/docs/src/main/resources/microsite/data/menu.yml
@@ -118,8 +118,8 @@ options:
     url: api/chisel3/latest/index.html
     menu_type: chisel3
     nested_options:
-      - title: master
-        url: api/chisel3/master/index.html
+      - title: SNAPSHOT
+        url: api/chisel3/SNAPSHOT/index.html
       - title: v3.1.8
         url: api/chisel3/v3.1.8/index.html
       - title: v3.1.7
@@ -153,8 +153,8 @@ options:
     url: api/chisel-testers/latest/index.html
     menu_type: chisel-testers
     nested_options:
-      - title: master
-        url: api/chisel-testers/master/index.html
+      - title: SNAPSHOT
+        url: api/chisel-testers/SNAPSHOT/index.html
       - title: v1.2.10
         url: api/chisel-testers/v1.2.10/index.html
       - title: v1.2.9
@@ -192,8 +192,8 @@ options:
     url: api/firrtl/latest/index.html
     menu_type: firrtl
     nested_options:
-      - title: master
-        url: api/firrtl/master/index.html
+      - title: SNAPSHOT
+        url: api/firrtl/SNAPSHOT/index.html
       - title: v1.1.7
         url: api/firrtl/v1.1.7/index.html
       - title: v1.1.6
@@ -225,8 +225,8 @@ options:
     url: api/treadle/latest/index.html
     menu_type: treadle
     nested_options:
-      - title: master
-        url: api/treadle/master/index.html
+      - title: SNAPSHOT
+        url: api/treadle/SNAPSHOT/index.html
       - title: v1.0.5
         url: api/treadle/v1.0.5/index.html
       - title: v1.0.4
@@ -248,8 +248,8 @@ options:
     url: api/diagrammer/latest/index.html
     menu_type: diagrammer
     nested_options:
-      - title: master
-        url: api/diagrammer/master/index.html
+      - title: SNAPSHOT
+        url: api/diagrammer/SNAPSHOT/index.html
       - title: v1.0.2
         url: api/diagrammer/v1.0.2/index.html
       - title: v1.0.1


### PR DESCRIPTION
This will build documentation for the latest snapshot release. This is intended to provide utility for people either working way ahead of the releases, using Rocket Chip/BOOM, or for Chisel/FIRRTL developers.

Fixes #16 