### PR TITLE
Add Chisel3 Resources

### DIFF
--- a/docs/src/main/resources/microsite/data/menu.yml
+++ b/docs/src/main/resources/microsite/data/menu.yml
@@ -12,6 +12,8 @@ options:
         url: chisel3/cookbook.html
       - title: Troubleshooting
         url: chisel3/troubleshooting
+      - title: Resources
+        url: chisel3/resources
   - title: Introduction
     url: chisel3/introduction.html
     menu_type: chisel3

--- a/docs/src/main/tut/chisel3/resources.md
+++ b/docs/src/main/tut/chisel3/resources.md
@@ -4,7 +4,7 @@ title:  "Resources and References"
 section: "chisel3"
 ---
 
-The *best resource* to learn about Chisel is the [**online Chisel Bootcamp**](https://mybinder.org/v2/gh/freechipsproject/chisel-bootcamp/master). This runs in your browser and assumes no prior Scala knowledge.
+The *best resource* to learn about Chisel is the [**online Chisel Bootcamp**](https://mybinder.org/v2/gh/freechipsproject/chisel-bootcamp/master). This runs in your browser and assumes no prior Scala knowledge. (You may also run this locally via the [backing chisel-bootcamp GitHub repository](https://github.com/freechipsproject/chisel-bootcamp).)
 
 When you're ready to build your own circuits in Chisel, **we recommend starting from the [Chisel Template](https://github.com/freechipsproject/chisel-template) repository**, which provides a pre-configured project, example design, and testbench. Follow the [chisel-template readme](https://github.com/freechipsproject/chisel-template) to get started.
 

--- a/docs/src/main/tut/chisel3/resources.md
+++ b/docs/src/main/tut/chisel3/resources.md
@@ -1,0 +1,13 @@
+---
+layout: docs
+title:  "Resources and References"
+section: "chisel3"
+---
+
+The *best resource* to learn about Chisel is the [**online Chisel Bootcamp**](https://mybinder.org/v2/gh/freechipsproject/chisel-bootcamp/master). This runs in your browser and assumes no prior Scala knowledge.
+
+When you're ready to build your own circuits in Chisel, **we recommend starting from the [Chisel Template](https://github.com/freechipsproject/chisel-template) repository**, which provides a pre-configured project, example design, and testbench. Follow the [chisel-template readme](https://github.com/freechipsproject/chisel-template) to get started.
+
+The following additional resources and references may be useful:
+
+- [Chisel Cheatsheet](https://github.com/freechipsproject/chisel-cheatsheet/releases/latest/download/chisel_cheatsheet.pdf)

--- a/docs/src/main/tut/chisel3/resources.md
+++ b/docs/src/main/tut/chisel3/resources.md
@@ -11,3 +11,4 @@ When you're ready to build your own circuits in Chisel, **we recommend starting 
 The following additional resources and references may be useful:
 
 - [Chisel Cheatsheet](https://github.com/freechipsproject/chisel-cheatsheet/releases/latest/download/chisel_cheatsheet.pdf)
+- [Digital Design With Chisel](https://github.com/schoeberl/chisel-book)


### PR DESCRIPTION
Add a "resources" page to the Chisel3 documentation website w/ a link to the bootcamp, project template, Chisel3 cheatsheet latest release, and @schoeberl book.

Related issue: https://github.com/freechipsproject/chisel3/issues/1169