### PR TITLE
Change API directory structure

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,16 +32,16 @@ treadleSnapshot = $(call getSnapshot,treadle)
 diagrammerSnapshot = $(call getSnapshot,diagrammer)
 
 api-copy = \
-	docs/target/site/api/chisel3/latest/index.html \
+	docs/target/site/api/latest/index.html \
 	docs/target/site/api/firrtl/latest/index.html \
 	docs/target/site/api/chisel-testers/latest/index.html \
 	docs/target/site/api/treadle/latest/index.html \
 	docs/target/site/api/diagrammer/latest/index.html \
-	$(chiselTags:%=docs/target/site/api/chisel3/%/index.html) docs/target/site/api/chisel3/SNAPSHOT/index.html \
-	$(firrtlTags:%=docs/target/site/api/firrtl/%/index.html) docs/target/site/api/firrtl/SNAPSHOT/index.html \
-	$(testersTags:%=docs/target/site/api/chisel-testers/%/index.html) docs/target/site/api/chisel-testers/SNAPSHOT/index.html \
-	$(treadleTags:%=docs/target/site/api/treadle/%/index.html) docs/target/site/api/treadle/SNAPSHOT/index.html \
-	$(diagrammerTags:%=docs/target/site/api/diagrammer/%/index.html) docs/target/site/api/diagrammer/SNAPSHOT/index.html
+	$(chiselTags:v%=docs/target/site/api/%/index.html) docs/target/site/api/SNAPSHOT/index.html \
+	$(firrtlTags:v%=docs/target/site/api/firrtl/%/index.html) docs/target/site/api/firrtl/SNAPSHOT/index.html \
+	$(testersTags:v%=docs/target/site/api/chisel-testers/%/index.html) docs/target/site/api/chisel-testers/SNAPSHOT/index.html \
+	$(treadleTags:v%=docs/target/site/api/treadle/%/index.html) docs/target/site/api/treadle/SNAPSHOT/index.html \
+	$(diagrammerTags:v%=docs/target/site/api/diagrammer/%/index.html) docs/target/site/api/diagrammer/SNAPSHOT/index.html
 
 .PHONY: all clean mrproper publish serve \
 	apis-chisel apis-firrtl apis-chisel-testers apis-treadle apis-diagrammer
@@ -51,11 +51,11 @@ api-copy = \
 	$(subprojects)/chisel-testers/%/.git $(subprojects)/chisel-testers/%/target/scala-$(scalaVersion)/api/index.html \
 	$(subprojects)/treadle/%/.git $(subprojects)/treadle/%/target/scala-$(scalaVersion)/api/index.html \
 	$(subprojects)/diagrammer/%/.git $(subprojects)/diagrammer/%/target/scala-$(scalaVersion)/api/index.html \
-	$(apis)/chisel3/%/index.html $(apis)/firrtl/%/index.html $(apis)/chisel-testers/%/index.html \
+	$(apis)/chisel3/v%/index.html $(apis)/firrtl/%/index.html $(apis)/chisel-testers/%/index.html \
 	$(apis)/treadle/%/index.html $(apis)/diagrammer/%/index.html \
-	docs/target/site/api/chisel3/%/ docs/target/site/api/firrtl/%/ docs/target/site/api/chisel-testers/%/ \
+	docs/target/site/api/%/ docs/target/site/api/firrtl/%/ docs/target/site/api/chisel-testers/%/ \
 	docs/target/site/api/treadle/%/ docs/target/site/api/diagrammer/%/ \
-	$(apis)/chisel3/%/ $(apis)/firrtl/%/ $(apis)/chisel-testers/%/ $(apis)/treadle/%/ $(apis)/diagrammer/%/
+	$(apis)/%/
 
 # Build the site into the default directory (docs/target/site)
 all: docs/target/site/index.html
@@ -104,7 +104,7 @@ diagrammer/target/scala-$(scalaVersion)/api/index.html: $(shell find diagrammer/
 	(cd diagrammer/ && sbt ++$(scalaVersion).$(scalaMinorVersion) doc)
 
 # Copy built API into site
-docs/target/site/api/chisel3/latest/index.html: chisel3/target/scala-$(scalaVersion)/unidoc/index.html | docs/target/site/api/chisel3/latest/
+docs/target/site/api/latest/index.html: chisel3/target/scala-$(scalaVersion)/unidoc/index.html | docs/target/site/api/latest/
 	cp -r $(dir $<)* $(dir $@)
 docs/target/site/api/firrtl/latest/index.html: firrtl/target/scala-$(scalaVersion)/unidoc/index.html | docs/target/site/api/firrtl/latest/
 	cp -r $(dir $<)* $(dir $@)
@@ -128,7 +128,7 @@ $(subprojects)/diagrammer/%/target/scala-$(scalaVersion)/api/index.html: | $(sub
 	(cd $(subprojects)/diagrammer/$* && sbt ++$(scalaVersion).$(scalaMinorVersion) doc)
 
 # Copy *SNAPSHOT* API of subprojects into API directory
-docs/target/site/api/chisel3/SNAPSHOT/index.html: $(apis)/chisel3/$(chiselSnapshot)/index.html | docs/target/site/api/chisel3/SNAPSHOT/
+docs/target/site/api/SNAPSHOT/index.html: $(apis)/chisel3/$(chiselSnapshot)/index.html | docs/target/site/api/SNAPSHOT/
 	cp -r $(dir $<)* $(dir $@)
 docs/target/site/api/firrtl/SNAPSHOT/index.html: $(apis)/firrtl/$(firrtlSnapshot)/index.html | docs/target/site/api/firrtl/SNAPSHOT/
 	cp -r $(dir $<)* $(dir $@)
@@ -152,15 +152,15 @@ $(apis)/diagrammer/%/index.html: $(subprojects)/diagrammer/%/target/scala-$(scal
 	cp -r $(dir $<)* $(dir $@)
 
 # Copy *old* API of subprojects from API directory into website
-docs/target/site/api/chisel3/%/index.html: $(apis)/chisel3/%/index.html | docs/target/site/api/chisel3/%/
+docs/target/site/api/%/index.html: $(apis)/chisel3/v%/index.html | docs/target/site/api/%/
 	cp -r $(dir $<)* $(dir $@)
-docs/target/site/api/firrtl/%/index.html: $(apis)/firrtl/%/index.html | docs/target/site/api/firrtl/%/
+docs/target/site/api/firrtl/%/index.html: $(apis)/firrtl/v%/index.html | docs/target/site/api/firrtl/%/
 	cp -r $(dir $<)* $(dir $@)
-docs/target/site/api/chisel-testers/%/index.html: $(apis)/chisel-testers/%/index.html | docs/target/site/api/chisel-testers/%/
+docs/target/site/api/chisel-testers/%/index.html: $(apis)/chisel-testers/v%/index.html | docs/target/site/api/chisel-testers/%/
 	cp -r $(dir $<)* $(dir $@)
-docs/target/site/api/treadle/%/index.html: $(apis)/treadle/%/index.html | docs/target/site/api/treadle/%/
+docs/target/site/api/treadle/%/index.html: $(apis)/treadle/v%/index.html | docs/target/site/api/treadle/%/
 	cp -r $(dir $<)* $(dir $@)
-docs/target/site/api/diagrammer/%/index.html: $(apis)/diagrammer/%/index.html | docs/target/site/api/diagrammer/%/
+docs/target/site/api/diagrammer/%/index.html: $(apis)/diagrammer/v%/index.html | docs/target/site/api/diagrammer/%/
 	cp -r $(dir $<)* $(dir $@)
 
 # Utilities to either fetch submodules or create directories
@@ -176,23 +176,7 @@ $(subprojects)/treadle/%/.git:
 	git clone "https://github.com/freechipsproject/treadle.git" --depth 1 --branch $* $(dir $@)
 $(subprojects)/diagrammer/%/.git:
 	git clone "https://github.com/freechipsproject/diagrammer.git" --depth 1 --branch $* $(dir $@)
-$(apis)/chisel3/%/:
+$(apis)/%/:
 	mkdir -p $@
-$(apis)/firrtl/%/:
-	mkdir -p $@
-$(apis)/chisel-testers/%/:
-	mkdir -p $@
-$(apis)/treadle/%/:
-	mkdir -p $@
-$(apis)/diagrammer/%/:
-	mkdir -p $@
-docs/target/site/api/chisel3/%/:
-	mkdir -p $@
-docs/target/site/api/firrtl/%/:
-	mkdir -p $@
-docs/target/site/api/chisel-testers/%/:
-	mkdir -p $@
-docs/target/site/api/treadle/%/:
-	mkdir -p $@
-docs/target/site/api/diagrammer/%/:
+docs/target/site/api/%/:
 	mkdir -p $@

--- a/build.sbt
+++ b/build.sbt
@@ -37,7 +37,7 @@ lazy val micrositeSettings = Seq(
   micrositeGithubRepo := "chisel3",
   micrositeGithubLinks := false,
   micrositeShareOnSocial := false,
-  micrositeDocumentationUrl := "api/chisel3/latest/",
+  micrositeDocumentationUrl := "api/latest/",
   micrositeDocumentationLabelDescription := "API Documentation",
   /* mdoc doesn't work with extraMDFiles so this is disabled for now */
   // micrositeCompilingDocsTool := WithMdoc,

--- a/docs/src/main/resources/microsite/data/menu.yml
+++ b/docs/src/main/resources/microsite/data/menu.yml
@@ -117,35 +117,35 @@ options:
       - title: Test Coverage
         url: chisel3/test-coverage.html
   - title: API Documentation
-    url: api/chisel3/latest/
+    url: api/latest/
     menu_type: chisel3
     nested_options:
       - title: SNAPSHOT
-        url: api/chisel3/SNAPSHOT/
-      - title: v3.1.8
-        url: api/chisel3/v3.1.8/
-      - title: v3.1.7
-        url: api/chisel3/v3.1.7/
-      - title: v3.1.6
-        url: api/chisel3/v3.1.6/
-      - title: v3.1.5
-        url: api/chisel3/v3.1.5/
-      - title: v3.1.4
-        url: api/chisel3/v3.1.4/
-      - title: v3.1.3
-        url: api/chisel3/v3.1.3/
-      - title: v3.1.2
-        url: api/chisel3/v3.1.2/
-      - title: v3.1.1
-        url: api/chisel3/v3.1.1/
-      - title: v3.1.0
-        url: api/chisel3/v3.1.0/
-      - title: v3.0.2
-        url: api/chisel3/v3.0.2/
-      - title: v3.0.1
-        url: api/chisel3/v3.0.1/
-      - title: v3.0.0
-        url: api/chisel3/v3.0.0/
+        url: api/SNAPSHOT/
+      - title: 3.1.8
+        url: api/3.1.8/
+      - title: 3.1.7
+        url: api/3.1.7/
+      - title: 3.1.6
+        url: api/3.1.6/
+      - title: 3.1.5
+        url: api/3.1.5/
+      - title: 3.1.4
+        url: api/3.1.4/
+      - title: 3.1.3
+        url: api/3.1.3/
+      - title: 3.1.2
+        url: api/3.1.2/
+      - title: 3.1.1
+        url: api/3.1.1/
+      - title: 3.1.0
+        url: api/3.1.0/
+      - title: 3.0.2
+        url: api/3.0.2/
+      - title: 3.0.1
+        url: api/3.0.1/
+      - title: 3.0.0
+        url: api/3.0.0/
 
   # Testers Site
   - title: Testers
@@ -157,34 +157,34 @@ options:
     nested_options:
       - title: SNAPSHOT
         url: api/chisel-testers/SNAPSHOT/
-      - title: v1.2.10
-        url: api/chisel-testers/v1.2.10/
-      - title: v1.2.9
-        url: api/chisel-testers/v1.2.9/
-      - title: v1.2.8
-        url: api/chisel-testers/v1.2.8/
-      - title: v1.2.7
-        url: api/chisel-testers/v1.2.7/
-      - title: v1.2.6
-        url: api/chisel-testers/v1.2.6/
-      - title: v1.2.5
-        url: api/chisel-testers/v1.2.5/
-      - title: v1.2.4
-        url: api/chisel-testers/v1.2.4/
-      - title: v1.2.3
-        url: api/chisel-testers/v1.2.3/
-      - title: v1.2.2
-        url: api/chisel-testers/v1.2.2/
-      - title: v1.2.1
-        url: api/chisel-testers/v1.2.1/
-      - title: v1.2.0
-        url: api/chisel-testers/v1.2.0/
-      - title: v1.1.2
-        url: api/chisel-testers/v1.1.2/
-      - title: v1.1.1
-        url: api/chisel-testers/v1.1.1/
-      - title: v1.1.0
-        url: api/chisel-testers/v1.1.0/
+      - title: 1.2.10
+        url: api/chisel-testers/1.2.10/
+      - title: 1.2.9
+        url: api/chisel-testers/1.2.9/
+      - title: 1.2.8
+        url: api/chisel-testers/1.2.8/
+      - title: 1.2.7
+        url: api/chisel-testers/1.2.7/
+      - title: 1.2.6
+        url: api/chisel-testers/1.2.6/
+      - title: 1.2.5
+        url: api/chisel-testers/1.2.5/
+      - title: 1.2.4
+        url: api/chisel-testers/1.2.4/
+      - title: 1.2.3
+        url: api/chisel-testers/1.2.3/
+      - title: 1.2.2
+        url: api/chisel-testers/1.2.2/
+      - title: 1.2.1
+        url: api/chisel-testers/1.2.1/
+      - title: 1.2.0
+        url: api/chisel-testers/1.2.0/
+      - title: 1.1.2
+        url: api/chisel-testers/1.1.2/
+      - title: 1.1.1
+        url: api/chisel-testers/1.1.1/
+      - title: 1.1.0
+        url: api/chisel-testers/1.1.0/
 
   # FIRRTL Site
   - title: FIRRTL
@@ -196,28 +196,28 @@ options:
     nested_options:
       - title: SNAPSHOT
         url: api/firrtl/SNAPSHOT/
-      - title: v1.1.7
-        url: api/firrtl/v1.1.7/
-      - title: v1.1.6
-        url: api/firrtl/v1.1.6/
-      - title: v1.1.5
-        url: api/firrtl/v1.1.5/
-      - title: v1.1.4
-        url: api/firrtl/v1.1.4/
-      - title: v1.1.3
-        url: api/firrtl/v1.1.3/
-      - title: v1.1.2
-        url: api/firrtl/v1.1.2/
-      - title: v1.1.1
-        url: api/firrtl/v1.1.1/
-      - title: v1.1.0
-        url: api/firrtl/v1.1.0/
-      - title: v1.0.2
-        url: api/firrtl/v1.0.2/
-      - title: v1.0.1
-        url: api/firrtl/v1.0.1/
-      - title: v1.0.0
-        url: api/firrtl/v1.0.0/
+      - title: 1.1.7
+        url: api/firrtl/1.1.7/
+      - title: 1.1.6
+        url: api/firrtl/1.1.6/
+      - title: 1.1.5
+        url: api/firrtl/1.1.5/
+      - title: 1.1.4
+        url: api/firrtl/1.1.4/
+      - title: 1.1.3
+        url: api/firrtl/1.1.3/
+      - title: 1.1.2
+        url: api/firrtl/1.1.2/
+      - title: 1.1.1
+        url: api/firrtl/1.1.1/
+      - title: 1.1.0
+        url: api/firrtl/1.1.0/
+      - title: 1.0.2
+        url: api/firrtl/1.0.2/
+      - title: 1.0.1
+        url: api/firrtl/1.0.1/
+      - title: 1.0.0
+        url: api/firrtl/1.0.0/
 
   # Treadle Site
   - title: Treadle
@@ -229,18 +229,18 @@ options:
     nested_options:
       - title: SNAPSHOT
         url: api/treadle/SNAPSHOT/
-      - title: v1.0.5
-        url: api/treadle/v1.0.5/
-      - title: v1.0.4
-        url: api/treadle/v1.0.4/
-      - title: v1.0.3
-        url: api/treadle/v1.0.3/
-      - title: v1.0.2
-        url: api/treadle/v1.0.2/
-      - title: v1.0.1
-        url: api/treadle/v1.0.1/
-      - title: v1.0.0
-        url: api/treadle/v1.0.0/
+      - title: 1.0.5
+        url: api/treadle/1.0.5/
+      - title: 1.0.4
+        url: api/treadle/1.0.4/
+      - title: 1.0.3
+        url: api/treadle/1.0.3/
+      - title: 1.0.2
+        url: api/treadle/1.0.2/
+      - title: 1.0.1
+        url: api/treadle/1.0.1/
+      - title: 1.0.0
+        url: api/treadle/1.0.0/
 
   # Diagrammer Site
   - title: Diagrammer
@@ -252,9 +252,9 @@ options:
     nested_options:
       - title: SNAPSHOT
         url: api/diagrammer/SNAPSHOT/
-      - title: v1.0.2
-        url: api/diagrammer/v1.0.2/
-      - title: v1.0.1
-        url: api/diagrammer/v1.0.1/
-      - title: v1.0.0
-        url: api/diagrammer/v1.0.0/
+      - title: 1.0.2
+        url: api/diagrammer/1.0.2/
+      - title: 1.0.1
+        url: api/diagrammer/1.0.1/
+      - title: 1.0.0
+        url: api/diagrammer/1.0.0/


### PR DESCRIPTION
This modifies the API directory structure to put chisel3 API directly
under chisel-lang/api/ (instead of under chisel-lang/api/chisel3/).
This also removes all "v" specifies in API paths, e.g., "v3.0.0" is
now "3.0.0".