### PR TITLE
Use native Scala version, other build fixes

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -6,14 +6,6 @@ import Version._
 
 val commonSettings = Seq.empty
 
-lazy val chisel = (project in file("chisel3"))
-  .settings(commonSettings)
-  .settings(scalacOptions ++= docSourceUrl("chisel3"))
-
-lazy val testers = (project in file("chisel-testers"))
-  .settings(commonSettings)
-  .settings(scalacOptions ++= docSourceUrl("chisel-testers"))
-
 fork := true
 
 val technologies: String =
@@ -140,5 +132,6 @@ lazy val docs = project
   .enablePlugins(MicrositesPlugin)
   .settings(commonSettings)
   .settings(micrositeSettings)
+  .settings(libraryDependencies += "edu.berkeley.cs" %% "chisel-iotesters" % "1.2.10")
   .settings(scalacOptions ++= (Seq("-Xsource:2.11")))
-  .dependsOn(chisel, contributors)
+  .dependsOn(contributors)


### PR DESCRIPTION
This fixes a bug where using `++2.12.6` to build documentation would result in dependency resolution failing (for any library dependency that did not have a published version of 2.12.6). Instead, documentation is built using whatever the `build.sbt` defined version is.

A consequence of this is that legacy documentation will show up as the "old style" Scaladoc 2.11 documentation if that version used a default Scala version of 2.11.x. It's not the end of the world, but it does mean that Chisel "latest" will show up as 2.11 documentation.

This changes the build process to *not* use submodules for documentation (but does not remove the submodules). Instead, documentation is built from explicit tags. 

This also changes the snapshot version to point at RC2.