### PR TITLE
Add edit button to documentation pages

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,6 +1,6 @@
 // See LICENSE for license details.
 
-import microsites.{MicrositeFavicon, ExtraMdFileConfig}
+import microsites.{MicrositeEditButton, MicrositeFavicon, ExtraMdFileConfig}
 
 import Version._
 
@@ -26,7 +26,7 @@ lazy val micrositeSettings = Seq(
   micrositeAuthor := "the Chisel/FIRRTL Developers",
   micrositeTwitter := "@chisel_lang",
   micrositeGithubOwner := "freechipsproject",
-  micrositeGithubRepo := "chisel3",
+  micrositeGithubRepo := "www.chisel-lang.org",
   micrositeGithubLinks := false,
   micrositeShareOnSocial := false,
   micrositeDocumentationUrl := "api/latest/",
@@ -80,6 +80,7 @@ lazy val micrositeSettings = Seq(
     "gray-lighter"      -> "#F4F3F4",
     "white-color"       -> "#FFFFFF"),
   micrositeAnalyticsToken := "UA-145179088-1",
+  micrositeEditButton := Some(MicrositeEditButton("Improve this Page", "/edit/master/docs/src/main/tut/{{ page.path }}")),
   autoAPIMappings := true,
   ghpagesNoJekyll := false,
   ghpagesRepository := file("build/gh-pages"),


### PR DESCRIPTION
Adds an "Improve this Page" edit button to every `layout: docs` page.

The following button:
![2019-09-26-143130_450x298_scrot](https://user-images.githubusercontent.com/1018530/65715046-580e5400-e06a-11e9-95a5-5781bb9c39cd.png)

Takes you directly to:

https://github.com/freechipsproject/www.chisel-lang.org/edit/master/docs/src/main/tut/chisel3/operators.md