### PR TITLE
Redirects

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -52,6 +52,7 @@ jobs:
         - gem update --system
         - gem install sass
         - gem install jekyll -v 3.8.5
+        - gem install jekyll-redirect-from
         - make
         - if [ "$TRAVIS_BRANCH" = "master" -a "$TRAVIS_PULL_REQUEST" = "false" ]; then make publish; fi
         - if [ "$TRAVIS_PULL_REQUEST" = "true" ]; then echo "Not in master branch, skipping deploy and release"; fi

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ subprojects = $(buildDir)/subprojects
 apis = $(buildDir)/api
 
 www-src = \
-	$(shell find docs/src/main/tut/ -name *.md) \
+	$(shell find docs/src/main/tut/ -name "*.md") \
 	$(shell find docs/src/main/resources) \
 	chisel3/README.md \
 	firrtl/README.md \

--- a/Makefile
+++ b/Makefile
@@ -127,7 +127,7 @@ apis-diagrammer: $(diagrammerTags:%=$(apis)/diagrammer/%/index.html) $(apis)/dia
 
 # Remove the output of all build targets
 clean:
-	rm -rf $(buildDir)/api docs/target docs/src/main/tut/contributors.md
+	rm -rf docs/target docs/src/main/tut/contributors.md
 
 # Remove everything
 mrproper:

--- a/Makefile
+++ b/Makefile
@@ -11,6 +11,9 @@ www-src = \
 	treadle/README.md \
 	diagrammer/README.md
 
+redirects = \
+	docs/target/site/doc/chisel-cheatsheet3.pdf/index.html
+
 firrtlTags = \
 	v1.0.0 \
 	v1.0.1 \
@@ -139,7 +142,7 @@ serve: all
 	(cd docs/target/site && jekyll serve)
 
 # Build the sbt-microsite
-docs/target/site/index.html: build.sbt docs/src/main/tut/contributors.md $(www-src) $(api-copy) | $(api-latest)
+docs/target/site/index.html: build.sbt docs/src/main/tut/contributors.md $(www-src) $(api-copy) $(redirects) | $(api-latest)
 	sbt docs/makeMicrosite
 
 # Determine contributors
@@ -209,6 +212,10 @@ docs/target/site/api/treadle/%/index.html: $(apis)/treadle/v%/index.html | docs/
 docs/target/site/api/diagrammer/%/index.html: $(apis)/diagrammer/v%/index.html | docs/target/site/api/diagrammer/%/
 	cp -r $(<D)/. $(@D)
 
+# Copy special meta refresh redirects that are files into the website
+docs/target/site/doc/chisel-cheatsheet3.pdf/index.html: docs/src/main/resources/redirects/chisel-cheatsheet3.html | docs/target/site/doc/chisel-cheatsheet3.pdf/
+	cp $< $@
+
 # Utilities to either fetch submodules or create directories
 %/.git:
 	git submodule update --init --depth 1 $*
@@ -222,7 +229,5 @@ $(subprojects)/treadle/%/.git:
 	git clone "https://github.com/freechipsproject/treadle.git" --depth 1 --branch $* $(dir $@)
 $(subprojects)/diagrammer/%/.git:
 	git clone "https://github.com/freechipsproject/diagrammer.git" --depth 1 --branch $* $(dir $@)
-$(apis)/%/:
-	mkdir -p $@
-docs/target/site/api/%/:
+%/:
 	mkdir -p $@

--- a/build.sbt
+++ b/build.sbt
@@ -1,6 +1,6 @@
 // See LICENSE for license details.
 
-import microsites.{MicrositeEditButton, MicrositeFavicon, ExtraMdFileConfig}
+import microsites.{ConfigYml, MicrositeEditButton, MicrositeFavicon, ExtraMdFileConfig}
 
 import Version._
 
@@ -22,6 +22,9 @@ lazy val micrositeSettings = Seq(
   micrositeName := "Chisel/FIRRTL",
   micrositeDescription := "Chisel/FIRRTL\nHardware Compiler Framework",
   micrositeUrl := "https://www.chisel-lang.org",
+  micrositeConfigYaml := ConfigYml(
+    yamlCustomProperties = Map("plugins" -> Seq("jekyll-redirect-from"))
+  ),
   micrositeBaseUrl := "",
   micrositeAuthor := "the Chisel/FIRRTL Developers",
   micrositeTwitter := "@chisel_lang",

--- a/docs/src/main/resources/redirects/chisel-cheatsheet3.html
+++ b/docs/src/main/resources/redirects/chisel-cheatsheet3.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html lang="en-US">
+  <meta charset="utf-8">
+  <title>Redirecting&hellip;</title>
+  <link href="https://github.com/freechipsproject/chisel-cheatsheet/releases/latest/download/chisel_cheatsheet.pdf">
+  <script>location="https://github.com/freechipsproject/chisel-cheatsheet/releases/latest/download/chisel_cheatsheet.pdf"</script>
+  <meta http-equiv="refresh" content="0; url=https://github.com/freechipsproject/chisel-cheatsheet/releases/latest/download/chisel_cheatsheet.pdf">
+  <meta name="robots" content="noindex">
+  <h1>Redirecting&hellip;</h1>
+  <a href="https://github.com/freechipsproject/chisel-cheatsheet/releases/latest/download/chisel_cheatsheet.pdf">Click here if you are not redirected.</a>
+</html>

--- a/docs/src/main/tut/api.md
+++ b/docs/src/main/tut/api.md
@@ -1,0 +1,3 @@
+---
+redirect_to: /api/latest
+---

--- a/docs/src/main/tut/community.md
+++ b/docs/src/main/tut/community.md
@@ -3,6 +3,7 @@ layout: page
 title:  "Community"
 section: "Community"
 position: 16
+redirect_from: /documentation
 ---
 
 ## Chisel Users Community


### PR DESCRIPTION
Fixes #27 

This adds the following meta refresh redirects:
```yml
- from: https://chisel.eecs.berkeley.edu/doc/chisel-cheatsheet3.pdf
  to: https://github.com/freechipsproject/chisel-cheatsheet/releases/latest/download/chisel_cheatsheet.pdf
- from: https://chisel.eecs.berkeley.edu/documentation.html
  to: https://chisel.eecs.berkeley.edu/community.html
- from: https://chisel.eecs.berkeley.edu/api/
  to: https://chisel.eecs.berkeley.edu/api/latest
```

This adds the [`jekyll-redirect-from` plugin](https://github.com/jekyll/jekyll-redirect-from) which lets you do add both `redirect_from` and `redirect_to` configurations to Jekyll's markdown header. This also adds a small framework for defining and copying manual redirects for things like files inside the Makefile as `jekyll-redirect-from` can't handle these. (This is used for `chisel-cheatsheet3.pdf`.)