### PR TITLE
Fix gitter link

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -31,6 +31,7 @@ lazy val micrositeSettings = Seq(
   micrositeShareOnSocial := false,
   micrositeDocumentationUrl := "api/latest/",
   micrositeDocumentationLabelDescription := "API Documentation",
+  micrositeGitterChannelUrl := "freechipsproject/chisel3",
   /* mdoc doesn't work with extraMDFiles so this is disabled for now */
   // micrositeCompilingDocsTool := WithMdoc,
   // mdocIn := file("docs/src/main/mdoc"),


### PR DESCRIPTION
This fixes a bug introduced by #34: changing the micrositeGithubRepo
to point to freechipsproject/www.chisel-lang.org (to point at the
correct repository for editing) broke the Gitter channel link which
should point at freechipsproject/chisel3. This corrects that.