### PR TITLE
Modernize Annotations Documentation

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -130,6 +130,6 @@ lazy val docs = project
   .enablePlugins(MicrositesPlugin)
   .settings(commonSettings)
   .settings(micrositeSettings)
-  .settings(libraryDependencies += "edu.berkeley.cs" %% "chisel-iotesters" % "1.2.10")
+  .settings(libraryDependencies += "edu.berkeley.cs" %% "chisel-iotesters" % "1.3.0")
   .settings(scalacOptions ++= (Seq("-Xsource:2.11")))
   .dependsOn(contributors)

--- a/docs/src/main/tut/chisel3/annotations.md
+++ b/docs/src/main/tut/chisel3/annotations.md
@@ -3,79 +3,137 @@ layout: docs
 title:  "Annotations"
 section: "chisel3"
 ---
-Annotations are used to mark modules and their elements in a way that can be accessed by Firrtl transformation passes.  Custom passes and the annotations that guide their behavior extend the circuit generation capabilities of Chisel/Firrtl.  This article focuses on the approach to building a library that contains Annotations and Transforms.  We will walk through  [src/test/scala/chiselTests/AnnotatingDiamondSpec.scala](https://github.com/ucb-bar/chisel3/blob/master/src/test/scala/chiselTests/AnnotatingDiamondSpec.scala) to see the basic concepts.
+
+`Annotation`s are metadata containers associated with zero or more "things" in a FIRRTL circuit.
+Commonly, `Annotation`s are used to communicate information from Chisel to a specific, custom FIRRTL `Transform`.
+In this way `Annotation`s can be viewed as the "arguments" that a specific `Transform` consumes.
+
+This article focuses on the approach to building a basic library that contains `Annotation`s and `Transform`s.
 
 ### Imports
-We need a few basic imports to reference the components we need.  The chisel3 is a standard
+We need a few basic imports to reference the components we need.
+
 ```scala mdoc:silent
 import chisel3._
-import chisel3.experimental.ChiselAnnotation
+import chisel3.experimental.{annotate, ChiselAnnotation, RunFirrtlTransform}
 import chisel3.internal.InstanceId
-import firrtl.{CircuitForm, CircuitState, LowForm, Transform}
-import firrtl.annotations.{Annotation, ModuleName, Named}
+
+import firrtl._
+import firrtl.annotations.{Annotation, SingleTargetAnnotation}
+import firrtl.annotations.{CircuitName, ComponentName, ModuleName, Named}
 ```
-### Write a transform
-This is an identity transform that returns whatever it is passed without alteration.  See [Writing Firrtl Transforms](/ucb-bar/firrtl/wiki) for the gory details on writing transforms that actually do something.
+
+### Define an `Annotation` and a `Transform`
+
+First, define an `Annotation` that contains a string associated with a `Named` thing in the Chisel circuit.
+This `InfoAnnotation` extends [`SingleTargetAnnotation`](https://www.chisel-lang.org/api/firrtl/1.2.0/firrtl/annotations/SingleTargetAnnotation.html), an `Annotation` associated with *one* thing in a FIRRTL circuit:
+
 ```scala mdoc:silent
-class IdentityTransform extends Transform {
-  override def inputForm: CircuitForm = LowForm
-  override def outputForm: CircuitForm = LowForm
+/** An annotation that contains some string information */
+case class InfoAnnotation(target: Named, info: String) extends SingleTargetAnnotation[Named] {
+  def duplicate(newTarget: Named) = this.copy(target = newTarget)
+}
+```
+
+> Note: `Named` is currently deprecated in favor of the more specific `Target`.
+> Currently, `Named` is still the advised approach for writing `Annotation`s.
+
+Second, define a `Transform` that consumes this `InfoAnnotation`.
+This `InfoTransform` simply reads all annotations, prints any `InfoAnnotation`s it finds, and removes them.
+
+```scala mdoc:invisible
+object Issue1228 {
+  /* Workaround for https://github.com/freechipsproject/firrtl/pull/1228 */
+  abstract class Transform extends firrtl.Transform {
+    override def name: String = this.getClass.getName
+  }
+}
+import Issue1228.Transform
+```
+
+```scala mdoc:silent
+/** A transform that reads InfoAnnotations and prints information about them */
+class InfoTransform extends Transform {
+  override def inputForm: CircuitForm = HighForm
+  override def outputForm: CircuitForm = HighForm
 
   override def execute(state: CircuitState): CircuitState = {
-    getMyAnnotations(state) match {
-      case Nil => state
-      case myAnnotations =>
-        // Use annotations contained in the myAnnotations list to modify state
-        // and return that modified state.
-        state
+    println("Starting transform 'IdentityTransform'")
+
+    val annotationsx = state.annotations.flatMap{
+      case InfoAnnotation(a: CircuitName, info) =>
+        println(s"  - Circuit '${a.serialize}' annotated with '$info'")
+        None
+      case InfoAnnotation(a: ModuleName, info) =>
+        println(s"  - Module '${a.serialize}' annotated with '$info'")
+        None
+      case InfoAnnotation(a: ComponentName, info) =>
+        println(s"  - Component '${a.serialize} annotated with '$info''")
+        None
+      case a =>
+        Some(a)
     }
-  }
-}
-```
-This creates a transform that operates on low Firrtl (LowForm) and returns low Firrtl.  ```getMyAnnotations``` returns a list of annotations for your pass.  This example does nothing with those annotations.
-### Create an Annotation Factory
-The following creates an annotation that is connected to your transform, note the ```classOf[IdentityTransform]```.  The unapply is a convenience method for extracting information from your annotation by using the Scala ```match``` operator.
-```scala mdoc:silent
-object IdentityAnnotation {
-  def apply(target: Named, value: String): Annotation = Annotation(target, classOf[IdentityTransform], value)
 
-  def unapply(a: Annotation): Option[(Named, String)] = a match {
-    case Annotation(named, t, value) if t == classOf[IdentityTransform] => Some((named, value))
-    case _ => None
-  }
-}
-```
-> note ```target: Named``` identifies a firrtl circuit component.  Annotations can refer to specific elements of a Module
-> such as registers or wires, or can point to a Module in the case of some more generic transformation.
-
-### Create an Annotator
-An Annotator is a trait that only be applied to a Module.  It provides an abstraction layer over the underlying Chisel annotation system.  In this example, the ```identify``` annotator takes an kind of circuit component reference (i.e. ```InstanceId```) and packages it with ```value``` to be available in the firrtl pass.  The library writer could place restrictions on the type of component and value.
-> The ```value``` passed to the Annotator does not have to be a string, but it must serializable into a string
-> for the ```value``` parameter of the ```ChiselAnnotation``` being created.
-
-```scala mdoc:silent
-trait IdentityAnnotator {
-  self: Module =>
-  def identify(component: InstanceId, value: String): Unit = {
-    annotate(ChiselAnnotation(component, classOf[IdentityTransform], value))
+    state.copy(annotations = annotationsx)
   }
 }
 ```
 
-### Using the Annotator
-Here is a module that uses our ```IdentityAnnotator```
+> Note: `inputForm` and `outputForm` will be deprecated in favor of a new dependency API that allows transforms to specify their dependencies more specifically than with circuit forms.
+> Full backwards compatibility for `inputForm` and `outputForm` will be maintained, however.
+
+### Create a Chisel API/Annotator
+
+Now, define a Chisel API to annotate Chisel things with this `InfoAnnotation`.
+This is commonly referred to as an "annotator".
+
+Here, define an object, `InfoAnnotator` with a method `info` that generates `InfoAnnotation`s.
+This uses the `chisel3.experimental.annotate` passed an anonymous `ChiselAnnotation` object.
+The need for this `ChiselAnnotation` (which is different from an actual FIRRTL `Annotation`) is that no FIRRTL circuit exists at the time the `info` method is called.
+This is delaying the generation of the `InfoAnnotation` until the full circuit is available.
+
+This annotator also mixes in the `RunFirrtlTransform` trait (abstract in the `transformClass` method) because this annotator, whenever used, should result in the FIRRTL compiler running the custom `InfoTransform`.
+
 ```scala mdoc:silent
-class ModC(widthC: Int) extends Module with IdentityAnnotator {
+object InfoAnnotator {
+  def info(component: InstanceId, info: String): Unit = {
+    annotate(new ChiselAnnotation with RunFirrtlTransform {
+      def toFirrtl: Annotation = InfoAnnotation(component.toNamed, info)
+      def transformClass = classOf[InfoTransform]
+    })
+  }
+}
+```
+
+> Note: there are a number of different approaches to writing an annotator.
+> You could use a trait that you mix into a `Module`, an object (like is done above), or any other software approach.
+> The specific choice of how you implement this is up to you!
+
+### Using the Chisel API
+
+Now, we can use the method `InfoAnnotation.info` to create annotations that associate strings with specific things in a FIRRTL circuit.
+Below is a Chisel `Module`, `ModC`, where both the actual module is annotated as well as an output.
+
+```scala mdoc:silent
+class ModC(widthC: Int) extends Module {
   val io = IO(new Bundle {
     val in = Input(UInt(widthC.W))
     val out = Output(UInt(widthC.W))
   })
   io.out := io.in
 
-  identify(this, s"ModC($widthC)")
+  InfoAnnotator.info(this, s"ModC($widthC)")
 
-  identify(io.out, s"ModC(ignore param)")
+  InfoAnnotator.info(io.out, s"ModC(ignore param)")
 }
 ```
 
-There are several things to note here.  ModC includes the ```with IdentityAnnotator``` which adds the identity method to it.  The ```identify(this, s"ModC($widthC)")``` annotates an instance of ModC as it is created.  It value annotations includes the ```widthC``` parameter to the constructor.  In this case that could be used to distinguish transformation behavior between different instances of ModC.  The ```identify(io.out, s"ModC(ignore param)")``` annotates io.out but with a fixed string.  In contrast the previous annotation, multiple instances of ModC would have result in a single ```io.out``` annotation here.
+### Running the Compilation
+
+Compiling this circuit to Verilog will then result in the `InfoTransform` running and the added `println`s showing information about the components annotated.
+
+```scala mdoc
+import chisel3.stage.{ChiselStage, ChiselGeneratorAnnotation}
+
+(new ChiselStage).execute(Array.empty, Seq(ChiselGeneratorAnnotation(() => new ModC(4))))
+```

--- a/docs/src/main/tut/chisel3/modules.md
+++ b/docs/src/main/tut/chisel3/modules.md
@@ -109,7 +109,7 @@ a specific naming convention for clock or reset.
 
 Then we can use it in place of *Module* usage :
 ```scala mdoc:silent
-import chisel3.experimental.{RawModule, withClockAndReset}
+import chisel3.{RawModule, withClockAndReset}
 
 class Foo extends Module {
   val io = IO(new Bundle{


### PR DESCRIPTION
This updates `annotations.md` to use the modern way of annotating things in Chisel. 

This runs afoul of https://github.com/freechipsproject/firrtl/pull/1228 and uses an invisible mdoc shed as a workaround.

![2019-11-07-131045_1304x1056_scrot](https://user-images.githubusercontent.com/1018530/68415318-15a75f00-0160-11ea-9e9e-e43ab82c9716.png)
![2019-11-07-131053_1304x1056_scrot](https://user-images.githubusercontent.com/1018530/68415319-163ff580-0160-11ea-84ce-aa6b3062c612.png)
![2019-11-07-131101_1304x1056_scrot](https://user-images.githubusercontent.com/1018530/68415320-163ff580-0160-11ea-8d0b-cdb3f98ee705.png)
![2019-11-07-131106_1304x1056_scrot](https://user-images.githubusercontent.com/1018530/68415321-163ff580-0160-11ea-8b41-d2fc6966b7e6.png)



