### PR TITLE
Cookbook Updates

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -95,7 +95,8 @@ lazy val micrositeSettings = Seq(
   excludeFilter in ghpagesCleanSite :=
     new FileFilter{
       def accept(f: File) = (ghpagesRepository.value / "CNAME").getCanonicalPath == f.getCanonicalPath
-    } || "versions.html"
+    } || "versions.html",
+  addCompilerPlugin("org.scalamacros" % "paradise" % "2.1.0" cross CrossVersion.full)
 )
 
 resolvers ++= Seq(

--- a/docs/src/main/tut/chisel3/cookbook.md
+++ b/docs/src/main/tut/chisel3/cookbook.md
@@ -6,7 +6,7 @@ section: "chisel3"
 
 Welcome to the Chisel cookbook. This cookbook is still in early stages. If you have any requests or examples to share, please [file an issue](https://github.com/ucb-bar/chisel3/issues/new) and let us know!
 
-Please note that these examples make use of [Chisel's scala-style printing](Printing-in-Chisel#scala-style).
+Please note that these examples make use of [Chisel's scala-style printing](printing#scala-style).
 
 * Converting Chisel Types to/from UInt
   * [How do I create a UInt from an instance of a Bundle?](#how-do-i-create-a-uint-from-an-instance-of-a-bundle)
@@ -16,7 +16,7 @@ Please note that these examples make use of [Chisel's scala-style printing](Prin
 * Vectors and Registers
   * [How do I create a Vector of Registers?](#how-do-i-create-a-vector-of-registers)
   * [How do I create a Reg of type Vec?](#how-do-i-create-a-reg-of-type-vec)
-* [How do I create a finite state machine?](#how-do-i-create-a-finite-state-machine)
+* [How do I create a finite state machine?](#how-do-i-create-a-finite-state-machine-fsm)
 * [How do I unpack a value ("reverse concatenation") like in Verilog?](#how-do-i-unpack-a-value-reverse-concatenation-like-in-verilog)
 * [How do I do subword assignment (assign to some bits in a UInt)?](#how-do-i-do-subword-assignment-assign-to-some-bits-in-a-uint)
 * [How can I dynamically set/parametrize the name of a module?](#how-can-i-dynamically-setparametrize-the-name-of-a-module)
@@ -27,76 +27,66 @@ Please note that these examples make use of [Chisel's scala-style printing](Prin
 
 ### How do I create a UInt from an instance of a Bundle?
 
-Call asUInt on the Bundle instance.
+Call [`asUInt`](https://www.chisel-lang.org/api/latest/chisel3/Bundle.html#asUInt():chisel3.UInt) on the [`Bundle`](https://www.chisel-lang.org/api/latest/chisel3/Bundle.html) instance.
 
-```scala
-  // Example
-  class MyBundle extends Bundle {
-    val foo = UInt(4.W)
-    val bar = UInt(4.W)
-  }
+```scala mdoc:silent:reset
+import chisel3._
+
+class MyBundle extends Bundle {
+  val foo = UInt(4.W)
+  val bar = UInt(4.W)
+}
+
+class Foo extends RawModule {
   val bundle = Wire(new MyBundle)
   bundle.foo := 0xc.U
   bundle.bar := 0x3.U
   val uint = bundle.asUInt
-  printf(p"$uint") // 195
-
-  // Test
-  assert(uint === 0xc3.U)
+}
 ```
 
 ### How do I create a Bundle from a UInt?
 
-On an instance of the Bundle, call the method fromBits with the UInt as the argument
+Use the [`asTypeOf`](https://www.chisel-lang.org/api/latest/chisel3/UInt.html#asTypeOf[T%3C:chisel3.Data](that:T):T) method to reinterpret the [`UInt`](https://www.chisel-lang.org/api/latest/chisel3/UInt.html) as the type of the [`Bundle`](https://www.chisel-lang.org/api/latest/chisel3/Bundle.html).
 
-```scala
-  // Example
-  class MyBundle extends Bundle {
-    val foo = UInt(4.W)
-    val bar = UInt(4.W)
-  }
+```scala mdoc:silent:reset
+import chisel3._
+
+class MyBundle extends Bundle {
+  val foo = UInt(4.W)
+  val bar = UInt(4.W)
+}
+
+class Foo extends RawModule {
   val uint = 0xb4.U
-  val bundle = (new MyBundle).fromBits(uint)
-  printf(p"$bundle") // Bundle(foo -> 11, bar -> 4)
-
-  // Test
-  assert(bundle.foo === 0xb.U)
-  assert(bundle.bar === 0x4.U)
+  val bundle = uint.asTypeOf(new MyBundle)
+}
 ```
 
 ### How do I create a Vec of Bools from a UInt?
 
-Use the builtin function chisel3.core.Bits.toBools to create a Scala Seq of Bool,
-then wrap the resulting Seq in Vec(...)
+Use [`VecInit`](https://www.chisel-lang.org/api/latest/chisel3/VecInit$.html) given a `Seq[Bool]` generated using the [`asBools`](https://www.chisel-lang.org/api/latest/chisel3/UInt.html#asBools():Seq[chisel3.Bool]) method.
 
-```scala
-  // Example
+```scala mdoc:silent:reset
+import chisel3._
+
+class Foo extends RawModule {
   val uint = 0xc.U
-  val vec = Vec(uint.toBools)
-  printf(p"$vec") // Vec(0, 0, 1, 1)
-
-  // Test
-  assert(vec(0) === false.B)
-  assert(vec(1) === false.B)
-  assert(vec(2) === true.B)
-  assert(vec(3) === true.B)
+  val vec = VecInit(uint.asBools)
+}
 ```
 
 ### How do I create a UInt from a Vec of Bool?
 
-Use the builtin function asUInt
+Use the builtin function [`asUInt`](https://www.chisel-lang.org/api/latest/chisel3/Vec.html#asUInt():chisel3.UInt)
 
-```scala
-  // Example
-  val vec = Vec(true.B, false.B, true.B, true.B)
+```scala mdoc:silent:reset
+import chisel3._
+
+class Foo extends RawModule {
+  val vec = VecInit(true.B, false.B, true.B, true.B)
   val uint = vec.asUInt
-  printf(p"$uint") // 13
-
-  /* Test
-   *
-   * (remember leftmost Bool in Vec is low order bit)
-   */
-  assert(0xd.U === uint)
+}
 ```
 
 ## Vectors and Registers
@@ -109,45 +99,57 @@ You create a [Reg of type Vec](#how-do-i-create-a-reg-of-type-vec). Because Vecs
 
 ### How do I create a Reg of type Vec?
 
-For information, please see the API documentation
-(https://chisel.eecs.berkeley.edu/api/index.html#chisel3.core.Vec)
+For more information, the API Documentation for [`Vec`](https://www.chisel-lang.org/api/latest/chisel3/Vec.html) provides more information.
 
-```scala
-  // Reg of Vec of 32-bit UInts without initialization
-  val regOfVec = Reg(Vec(4, UInt(32.W)))
-  regOfVec(0) := 123.U // a couple of assignments
-  regOfVec(2) := regOfVec(0)
+```scala mdoc:silent:reset
+import chisel3._
+
+class Foo extends RawModule {
+  val regOfVec = Reg(Vec(4, UInt(32.W))) // Register of 32-bit UInts
+  regOfVec(0) := 123.U                   // Assignments to elements of the Vec
+  regOfVec(1) := 456.U
+  regOfVec(2) := 789.U
+  regOfVec(3) := regOfVec(0)
 
   // Reg of Vec of 32-bit UInts initialized to zero
   //   Note that Seq.fill constructs 4 32-bit UInt literals with the value 0
   //   VecInit(...) then constructs a Wire of these literals
   //   The Reg is then initialized to the value of the Wire (which gives it the same type)
   val initRegOfVec = RegInit(VecInit(Seq.fill(4)(0.U(32.W))))
-
-  // Simple test (cycle comes from superclass)
-  when (cycle === 2.U) { assert(regOfVec(2) === 123.U) }
-  for (elt <- initRegOfVec) { assert(elt === 0.U) }
+}
 ```
 
-### How do I create a finite state machine?
+### How do I create a finite state machine (FSM)?
 
-Use Chisel Enum to construct the states and switch & is to construct the FSM
-control logic.
+The advised way is to use [`ChiselEnum`](https://www.chisel-lang.org/api/latest/chisel3/experimental/index.html#ChiselEnum=chisel3.experimental.EnumFactory) to construct enumerated types representing the state of the FSM.
+State transitions are then handled with [`switch`](https://www.chisel-lang.org/api/latest/chisel3/util/switch$.html)/[`is`](https://www.chisel-lang.org/api/latest/chisel3/util/is$.html) and [`when`](https://www.chisel-lang.org/api/latest/chisel3/when$.html)/[`.elsewhen`](https://www.chisel-lang.org/api/latest/chisel3/WhenContext.html#elsewhen(elseCond:=%3Echisel3.Bool)(block:=%3EUnit)(implicitsourceInfo:chisel3.internal.sourceinfo.SourceInfo,implicitcompileOptions:chisel3.CompileOptions):chisel3.WhenContext)/[`.otherwise`](https://www.chisel-lang.org/api/latest/chisel3/WhenContext.html#otherwise(block:=%3EUnit)(implicitsourceInfo:chisel3.internal.sourceinfo.SourceInfo,implicitcompileOptions:chisel3.CompileOptions):Unit).
 
-```scala
+```scala mdoc:silent:reset
 import chisel3._
 import chisel3.util._
+import chisel3.experimental.ChiselEnum
 
+object DetectTwoOnes {
+  object State extends ChiselEnum {
+    val sNone, sOne1, sTwo1s = Value
+  }
+}
+
+/* This FSM detects two 1's one after the other */
 class DetectTwoOnes extends Module {
+  import DetectTwoOnes.State
+  import DetectTwoOnes.State._
+
   val io = IO(new Bundle {
     val in = Input(Bool())
     val out = Output(Bool())
+    val state = Output(State())
   })
 
-  val sNone :: sOne1 :: sTwo1s :: Nil = Enum(3)
   val state = RegInit(sNone)
 
   io.out := (state === sTwo1s)
+  io.state := state
 
   switch (state) {
     is (sNone) {
@@ -171,9 +173,11 @@ class DetectTwoOnes extends Module {
 }
 ```
 
-The `is` statement can take multiple conditions e.g. `is (sTwo1s, sOne1) { ... }`.
+Note: the `is` statement can take multiple conditions e.g. `is (sTwo1s, sOne1) { ... }`.
 
 ### How do I unpack a value ("reverse concatenation") like in Verilog?
+
+In Verilog, you can do something like the following which will unpack a the value `z`:
 
 ```verilog
 wire [1:0] a;
@@ -183,9 +187,12 @@ wire [8:0] z = [...];
 assign {a,b,c} = z;
 ```
 
-Unpacking often corresponds to reinterpreting an unstructured data type as a structured data type. Frequently, this structured type is used prolifically in the design, and has been declared as in the following example:
+Unpacking often corresponds to reinterpreting an unstructured data type as a structured data type.
+Frequently, this structured type is used prolifically in the design, and has been declared as in the following example:
 
-```scala
+```scala mdoc:silent:reset
+import chisel3._
+
 class MyBundle extends Bundle {
   val a = UInt(2.W)
   val b = UInt(4.W)
@@ -195,24 +202,30 @@ class MyBundle extends Bundle {
 
 The easiest way to accomplish this in Chisel would be:
 
-```scala
-val z = Wire(UInt(9.W))
-// z := ...
-val unpacked = z.asTypeOf(new MyBundle)
-unpacked.a
-unpacked.b
-unpacked.c
+```scala mdoc:silent
+class Foo extends RawModule {
+  val z = Wire(UInt(9.W))
+  z := DontCare // This is a dummy connection
+  val unpacked = z.asTypeOf(new MyBundle)
+  unpacked.a
+  unpacked.b
+  unpacked.c
+}
 ```
 
 If you **really** need to do this for a one-off case (Think thrice! It is likely you can better structure the code using bundles), then rocket-chip has a [Split utility](https://github.com/freechipsproject/rocket-chip/blob/723af5e6b69e07b5f94c46269a208a8d65e9d73b/src/main/scala/util/Misc.scala#L140) which can accomplish this.
 
 ### How do I do subword assignment (assign to some bits in a UInt)?
 
-Example:
-```scala
-class TestModule extends Module {
+You may try to do something like the following where you want to assign only some bits of a Chisel type.
+Below, the left-hand side connection to `io.out(0)` is not allowed.
+
+```scala mdoc:silent:reset
+import chisel3._
+import chisel3.stage.{ChiselStage, ChiselGeneratorAnnotation}
+
+class Foo extends Module {
   val io = IO(new Bundle {
-    val in = Input(UInt(10.W))
     val bit = Input(Bool())
     val out = Output(UInt(10.W))
   })
@@ -220,18 +233,26 @@ class TestModule extends Module {
 }
 ```
 
-Chisel3 does not support subword assignment. We find that this type of thing can usually be better expressed with aggregate/structured types: Bundles and Vecs.
+If you try to compile this, you will get an error.
+```scala mdoc:crash
+(new ChiselStage).execute(Array("-X", "verilog"), Seq(new ChiselGeneratorAnnotation(() => new Foo)))
+```
 
-If you must express it this way, you can blast your UInt to a Vec of Bools and back:
+Chisel3 *does not support subword assignment*.
+The reason for this is that subword assignment generally hints at a better abstraction with an aggregate/structured types, i.e., a `Bundle` or a `Vec`.
 
-```scala
-class TestModule extends Module {
+If you must express it this way, one approach is to blast your `UInt` to a `Vec` of `Bool` and back:
+
+```scala mdoc:silent:reset
+import chisel3._
+
+class Foo extends Module {
   val io = IO(new Bundle {
     val in = Input(UInt(10.W))
     val bit = Input(Bool())
     val out = Output(UInt(10.W))
   })
-  val bools = VecInit(io.in.toBools)
+  val bools = VecInit(io.in.asBools)
   bools(0) := io.bit
   io.out := bools.asUInt
 }
@@ -240,7 +261,10 @@ class TestModule extends Module {
 ### How can I dynamically set/parametrize the name of a module?
 
 You can override the `desiredName` function. This works with normal Chisel modules and `BlackBox`es. Example:
-```scala
+
+```scala mdoc:silent:reset
+import chisel3._
+
 class Coffee extends BlackBox {
     val io = IO(new Bundle {
         val I = Input(UInt(32.W))
@@ -248,6 +272,7 @@ class Coffee extends BlackBox {
     })
     override def desiredName = "Tea"
 }
+
 class Salt extends Module {
     val io = IO(new Bundle {})
     val drink = Module(new Coffee)
@@ -255,27 +280,27 @@ class Salt extends Module {
 }
 ```
 
-Elaborating the Chisel module `Salt` yields:
-```verilog
-module SodiumMonochloride(
-  input   clock,
-  input   reset
-);
-  wire [31:0] drink_O;
-  wire [31:0] drink_I;
-  Tea drink (
-    .O(drink_O),
-    .I(drink_I)
-  );
-  assign drink_I = 32'h0;
-endmodule
+Elaborating the Chisel module `Salt` yields our "desire name" for `Salt` and `Coffee` in the output Verilog:
+```scala mdoc:passthrough
+import chisel3.stage.{ChiselStage, ChiselGeneratorAnnotation}
+import firrtl.annotations.DeletedAnnotation
+import firrtl.EmittedVerilogCircuitAnnotation
+
+(new ChiselStage)
+  .execute(Array("-X", "verilog"), Seq(ChiselGeneratorAnnotation(() => new Salt)))
+  .collectFirst{ case DeletedAnnotation(_, a: EmittedVerilogCircuitAnnotation) => a.value.value }
+  .foreach(a => println(s"""|```verilog
+                            |$a
+                            |```""".stripMargin))
 ```
 
 ### How do I create an optional I/O?
 
 The following example is a module which includes the optional port `out2` only if the given parameter is `true`.
 
-```scala
+```scala mdoc:silent:reset
+import chisel3._
+
 class ModuleWithOptionalIOs(flag: Boolean) extends Module {
   val io = IO(new Bundle {
     val in = Input(UInt(12.W))
@@ -292,9 +317,9 @@ class ModuleWithOptionalIOs(flag: Boolean) extends Module {
 
 ### How do I get Chisel to name signals properly in blocks like when/withClockAndReset?
 
-To get Chisel to name signals (wires and registers) declared inside of blocks like `when`, `withClockAndReset`, etc, use the `chiselName` annotation as shown below:
+To get Chisel to name signals (wires and registers) declared inside of blocks like `when`, `withClockAndReset`, etc, use the [`@chiselName`](https://www.chisel-lang.org/api/latest/chisel3/experimental/package$$chiselName.html) annotation as shown below:
 
-```scala
+```scala mdoc:silent:reset
 import chisel3._
 import chisel3.experimental.chiselName
 
@@ -316,52 +341,46 @@ class TestMod extends Module {
 
 Note that you will need to add the following line to your project's `build.sbt` file.
 
-```
+```scala
 addCompilerPlugin("org.scalamacros" % "paradise" % "2.1.0" cross CrossVersion.full)
 ```
 
-Without `chiselName`, Chisel is not able to name `innerReg` correctly (notice the `_T`):
+If we compile this module *without* `@chiselName`, Chisel is not able to name `innerReg` correctly (notice the `_T`):
 
-```verilog
-module TestMod(
-  input        clock,
-  input        reset,
-  input        io_a,
-  output [3:0] io_b
-);
-  reg [3:0] _T;
-  wire [3:0] _T_2;
-  assign _T_2 = _T + 4'h1;
-  assign io_b = io_a ? _T : 4'ha;
-  always @(posedge clock) begin
-    if (reset) begin
-      _T <= 4'h5;
-    end else begin
-      _T <= _T_2;
-    end
-  end
-endmodule
+```scala mdoc:passthrough
+import chisel3.stage.{ChiselStage, ChiselGeneratorAnnotation}
+import firrtl.annotations.DeletedAnnotation
+import firrtl.EmittedVerilogCircuitAnnotation
+
+class TestModWithout extends Module {
+  override val desiredName = "TestMod"
+  val io = IO(new Bundle {
+    val a = Input(Bool())
+    val b = Output(UInt(4.W))
+  })
+  when (io.a) {
+    val innerReg = RegInit(5.U(4.W))
+    innerReg := innerReg + 1.U
+    io.b := innerReg
+  } .otherwise {
+    io.b := 10.U
+  }
+}
+
+(new ChiselStage)
+  .execute(Array("-X", "verilog"), Seq(ChiselGeneratorAnnotation(() => new TestModWithout)))
+  .collectFirst{ case DeletedAnnotation(_, a: EmittedVerilogCircuitAnnotation) => a.value.value }
+  .foreach(a => println(s"""|```verilog
+                            |$a
+                            |```""".stripMargin))
 ```
 
-In contrast, Chisel is able to name `innerReg` correctly with `chiselName`:
-
-```verilog
-module TestMod(
-  input        clock,
-  input        reset,
-  input        io_a,
-  output [3:0] io_b
-);
-  reg [3:0] innerReg;
-  wire [3:0] _T_1;
-  assign _T_1 = innerReg + 4'h1;
-  assign io_b = io_a ? innerReg : 4'ha;
-  always @(posedge clock) begin
-    if (reset) begin
-      innerReg <= 4'h5;
-    end else begin
-      innerReg <= _T_1;
-    end
-  end
-endmodule
+However, if we use `@chiselName` then the register previously called `_T` is now `innerReg`:
+```scala mdoc:passthrough
+(new ChiselStage)
+  .execute(Array("-X", "verilog"), Seq(ChiselGeneratorAnnotation(() => new TestMod)))
+  .collectFirst{ case DeletedAnnotation(_, a: EmittedVerilogCircuitAnnotation) => a.value.value }
+  .foreach(a => println(s"""|```verilog
+                            |$a
+                            |```""".stripMargin))
 ```


### PR DESCRIPTION
This corrects a few problems with the Cookbook with `Vec` instead of `VecInit`.

This depends on: https://github.com/freechipsproject/www.chisel-lang.org/pull/46.