### PR TITLE
cookbook.md: toBools is deprecated according to warning

### DIFF
--- a/docs/src/main/tut/chisel3/cookbook.md
+++ b/docs/src/main/tut/chisel3/cookbook.md
@@ -66,13 +66,13 @@ On an instance of the Bundle, call the method fromBits with the UInt as the argu
 
 ### How do I create a Vec of Bools from a UInt?
 
-Use the builtin function chisel3.core.Bits.toBools to create a Scala Seq of Bool,
+Use the builtin function chisel3.core.Bits.asBools to create a Scala Seq of Bool,
 then wrap the resulting Seq in Vec(...)
 
 ```scala
   // Example
   val uint = 0xc.U
-  val vec = Vec(uint.toBools)
+  val vec = Vec(uint.asBools)
   printf(p"$vec") // Vec(0, 0, 1, 1)
 
   // Test
@@ -231,7 +231,7 @@ class TestModule extends Module {
     val bit = Input(Bool())
     val out = Output(UInt(10.W))
   })
-  val bools = VecInit(io.in.toBools)
+  val bools = VecInit(io.in.asBools)
   bools(0) := io.bit
   io.out := bools.asUInt
 }


### PR DESCRIPTION
I get this warnings when I use toBools : 
```scala
[deprecated] Bits.scala:320 (1 calls): do_toBools is deprecated: "Use asBools instead"
[warn] There were 1 deprecated function(s) used. These may stop compiling in a future release - you are encouraged to fix these issues.
[warn] Line numbers for deprecations reported by Chisel may be inaccurate; enable scalac compiler deprecation warnings via either of the following methods:
[warn]   In the sbt interactive console, enter:
[warn]     set scalacOptions in ThisBuild ++= Seq("-unchecked", "-deprecation")
[warn]   or, in your build.sbt, add the line:
[warn]     scalacOptions := Seq("-unchecked", "-deprecation")
```