### PR TITLE
Bump APIs to latest minor release

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,8 @@ firrtlTags = \
 	v1.1.6 \
 	v1.1.7 \
 	v1.2.0 \
-	v1.2.1
+	v1.2.1 \
+	v1.2.2
 chiselTags = \
 	v3.0.0 \
 	v3.0.1 \
@@ -40,7 +41,8 @@ chiselTags = \
 	v3.1.7 \
 	v3.1.8 \
 	v3.2.0 \
-	v3.2.1
+	v3.2.1 \
+	v3.2.2
 testersTags = \
 	v1.1.0 \
 	v1.1.1 \
@@ -57,7 +59,8 @@ testersTags = \
 	v1.2.9 \
 	v1.2.10 \
 	v1.3.0 \
-	v1.3.1
+	v1.3.1 \
+	v1.3.2
 treadleTags = \
 	v1.0.0 \
 	v1.0.1 \
@@ -66,24 +69,27 @@ treadleTags = \
 	v1.0.4 \
 	v1.0.5 \
 	v1.1.0 \
-	v1.1.1
+	v1.1.1 \
+	v1.1.2
 diagrammerTags = \
 	v1.0.0 \
 	v1.0.1 \
 	v1.0.2 \
 	v1.1.0 \
-	v1.1.1
+	v1.1.1 \
+	v1.1.2
 chiseltestTags = \
 	v0.1.0 \
-	v0.1.1
+	v0.1.1 \
+	v0.1.2
 
 # Snapshot versions that will have their API published.
-firrtlSnapshot = v1.2.1
-chiselSnapshot = v3.2.1
-testersSnapshot = v1.3.1
-treadleSnapshot = v1.1.1
-diagrammerSnapshot = v1.1.1
-chiseltestSnapshot = v0.1.1
+firrtlSnapshot = v1.2.2
+chiselSnapshot = v3.2.2
+testersSnapshot = v1.3.2
+treadleSnapshot = v1.1.2
+diagrammerSnapshot = v1.1.2
+chiseltestSnapshot = v0.1.2
 
 # Get the latest version of some sequence of version strings
 # Usage: $(call getTags,$(foo))

--- a/docs/src/main/resources/microsite/data/menu.yml
+++ b/docs/src/main/resources/microsite/data/menu.yml
@@ -122,6 +122,8 @@ options:
     nested_options:
       - title: SNAPSHOT
         url: api/SNAPSHOT/
+      - title: 3.2.2
+        url: api/3.2.2/
       - title: 3.2.1
         url: api/3.2.1/
       - title: 3.2.0
@@ -161,6 +163,8 @@ options:
     nested_options:
       - title: SNAPSHOT
         url: api/chisel-testers/SNAPSHOT/
+      - title: 1.3.2
+        url: api/chisel-testers/1.3.2/
       - title: 1.3.1
         url: api/chisel-testers/1.3.1/
       - title: 1.3.0
@@ -204,6 +208,8 @@ options:
     nested_options:
       - title: SNAPSHOT
         url: api/chiseltest/SNAPSHOT/
+      - title: 0.1.2
+        url: api/chiseltest/0.1.2/
       - title: 0.1.1
         url: api/chiseltest/0.1.1/
       - title: 0.1.0
@@ -219,6 +225,8 @@ options:
     nested_options:
       - title: SNAPSHOT
         url: api/firrtl/SNAPSHOT/
+      - title: 1.2.2
+        url: api/firrtl/1.2.2/
       - title: 1.2.1
         url: api/firrtl/1.2.1/
       - title: 1.2.0
@@ -256,6 +264,8 @@ options:
     nested_options:
       - title: SNAPSHOT
         url: api/treadle/SNAPSHOT/
+      - title: 1.1.2
+        url: api/treadle/1.1.2/
       - title: 1.1.1
         url: api/treadle/1.1.1/
       - title: 1.1.0
@@ -283,6 +293,8 @@ options:
     nested_options:
       - title: SNAPSHOT
         url: api/diagrammer/SNAPSHOT/
+      - title: 1.1.2
+        url: api/diagrammer/1.1.2/
       - title: 1.1.1
         url: api/diagrammer/1.1.1/
       - title: 1.1.0


### PR DESCRIPTION
Bump to 3.2.2 for Chisel3 and equivalents for other tools.