### PR TITLE
Fix bad links to "Unconnected-Wires"

### DIFF
--- a/docs/src/main/tut/chisel3/faqs.md
+++ b/docs/src/main/tut/chisel3/faqs.md
@@ -225,7 +225,7 @@ res3: java.io.File = output.fir
 ### Why doesn't Chisel tell me which wires aren't connected?
 
 As of commit [c313e13](https://github.com/freechipsproject/chisel3/commit/c313e137d4e562ef20195312501840ceab8cbc6a) it can!
-Please visit the wiki page [Unconnected Wires](Unconnected-Wires) for details.
+Please visit the wiki page [Unconnected Wires](unconnected-wires) for details.
 
 ### What does `Reference ... is not fully initialized.` mean?
 
@@ -234,4 +234,4 @@ It means that you have unconnected wires in your design which could be an indica
 In Chisel2 compatibility mode (`NotStrict` compile options), chisel generates firrtl code that disables firrtl's initialized wire checks.
 In pure chisel3 (`Strict` compile options), the generated firrtl code does not contain these disablers (`is invalid`).
 Output wires that are not driven (not connected) are reported by firrtl as `not fully initialized`.
-Please visit the wiki page [Unconnected Wires](Unconnected-Wires) for details on solving the problem.
+Please visit the wiki page [Unconnected Wires](unconnected-wires) for details on solving the problem.

--- a/docs/src/main/tut/chisel3/memories.md
+++ b/docs/src/main/tut/chisel3/memories.md
@@ -75,7 +75,7 @@ when (write) { mem.write(addr, dataIn); dataOut := DontCare }
 .otherwise { dataOut := mem.read(addr, read) }
 ```
 
-(The `DontCare` is there to make Chisel's [unconnected wire detection](Unconnected-Wires) aware that reading while writing is undefined.)
+(The `DontCare` is there to make Chisel's [unconnected wire detection](unconnected-wires) aware that reading while writing is undefined.)
 
 If the same `Mem` address is both written and sequentially read on the same clock
 edge, or if a sequential read enable is cleared, then the read data is


### PR DESCRIPTION
This fixes bad links to the non-existent page: `Unconnected-Wires`. This should be `unconnected-wires`. This appears to be due to renaming files when migrating from the wiki.

h/t @rpadler

Fixes #60 