### PR TITLE
Add a MultiIO example of an optional I/O

### DIFF
--- a/docs/src/main/tut/chisel3/cookbook.md
+++ b/docs/src/main/tut/chisel3/cookbook.md
@@ -322,7 +322,7 @@ import chisel3._
 
 class ModuleWithOptionalIO(flag: Boolean) extends MultiIOModule {
   val in = if (flag) Some(IO(Input(Bool()))) else None
-  val out = IO(Output(Bool())
+  val out = IO(Output(Bool()))
 
   out := if (flag) in.get else false.B
 }

--- a/docs/src/main/tut/chisel3/cookbook.md
+++ b/docs/src/main/tut/chisel3/cookbook.md
@@ -315,6 +315,19 @@ class ModuleWithOptionalIOs(flag: Boolean) extends Module {
 }
 ```
 
+The following is an example for a `MultiIO` module where the entire `IO` is optional:
+
+```scala mdoc:silent:reset
+import chisel3._
+
+class ModuleWithOptionalIO(flag: Boolean) extends MultiIOModule {
+  val in = if (flag) Some(IO(Input(Bool()))) else None
+  val out = IO(Output(Bool())
+
+  out := if (flag) in.get else false.B
+}
+```
+
 ### How do I get Chisel to name signals properly in blocks like when/withClockAndReset?
 
 To get Chisel to name signals (wires and registers) declared inside of blocks like `when`, `withClockAndReset`, etc, use the [`@chiselName`](https://www.chisel-lang.org/api/latest/chisel3/experimental/package$$chiselName.html) annotation as shown below:

--- a/docs/src/main/tut/chisel3/cookbook.md
+++ b/docs/src/main/tut/chisel3/cookbook.md
@@ -324,7 +324,7 @@ class ModuleWithOptionalIO(flag: Boolean) extends MultiIOModule {
   val in = if (flag) Some(IO(Input(Bool()))) else None
   val out = IO(Output(Bool()))
 
-  out := if (flag) in.get else false.B
+  out := in.getOrElse(false.B)
 }
 ```
 

--- a/docs/src/main/tut/chisel3/cookbook.md
+++ b/docs/src/main/tut/chisel3/cookbook.md
@@ -315,7 +315,7 @@ class ModuleWithOptionalIOs(flag: Boolean) extends Module {
 }
 ```
 
-The following is an example for a `MultiIO` module where the entire `IO` is optional:
+The following is an example for a `MultiIOModule` where an entire `IO` is optional:
 
 ```scala mdoc:silent:reset
 import chisel3._


### PR DESCRIPTION
I think the current example doesn't really show how to do it when the entire IO is optional. I get an error currently that IO can't take an Option[Data]. 