### PR TITLE
Bump to 3.3.0-RC1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,9 +17,9 @@ git:
   depth: false
 
 scala:
-  - 2.12.6
+  - 2.12.11
 env:
-  - buildDir=$HOME/build scalaVersion=2.12 scalaMinorVersion=6
+  - buildDir=$HOME/build scalaVersion=2.12 scalaMinorVersion=11
 
 jdk:
   - openjdk8

--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,8 @@ firrtlTags = \
 	v1.2.1 \
 	v1.2.2 \
 	v1.2.3 \
-	v1.2.4
+	v1.2.4 \
+	v1.3.0-RC1
 chiselTags = \
 	v3.0.0 \
 	v3.0.1 \
@@ -46,7 +47,8 @@ chiselTags = \
 	v3.2.1 \
 	v3.2.2 \
 	v3.2.3 \
-	v3.2.4
+	v3.2.4 \
+	v3.3.0-RC1
 testersTags = \
 	v1.1.0 \
 	v1.1.1 \
@@ -66,7 +68,8 @@ testersTags = \
 	v1.3.1 \
 	v1.3.2 \
 	v1.3.3 \
-	v1.3.4
+	v1.3.4 \
+	v1.4.0-RC1
 treadleTags = \
 	v1.0.0 \
 	v1.0.1 \
@@ -78,7 +81,8 @@ treadleTags = \
 	v1.1.1 \
 	v1.1.2 \
 	v1.1.3 \
-	v1.1.4
+	v1.1.4 \
+  v1.2.0-RC1
 diagrammerTags = \
 	v1.0.0 \
 	v1.0.1 \
@@ -87,21 +91,23 @@ diagrammerTags = \
 	v1.1.1 \
 	v1.1.2 \
 	v1.1.3 \
-	v1.1.4
+	v1.1.4 \
+	v1.2.0-RC1
 chiseltestTags = \
 	v0.1.0 \
 	v0.1.1 \
 	v0.1.2 \
 	v0.1.3 \
-	v0.1.4
+	v0.1.4 \
+	v0.2.0-RC1
 
 # Snapshot versions that will have their API published.
-firrtlSnapshot = v1.2.4
-chiselSnapshot = v3.2.4
-testersSnapshot = v1.3.4
-treadleSnapshot = v1.1.4
-diagrammerSnapshot = v1.1.4
-chiseltestSnapshot = v0.1.4
+firrtlSnapshot = v1.3.0-RC1
+chiselSnapshot = v3.3.0-RC1
+testersSnapshot = v1.4.0-RC1
+treadleSnapshot = v1.2.0-RC1
+diagrammerSnapshot = v1.2.0-RC1
+chiseltestSnapshot = v0.2.0-RC1
 
 # Get the latest version of some sequence of version strings
 # Usage: $(call getTags,$(foo))

--- a/build.sbt
+++ b/build.sbt
@@ -136,6 +136,6 @@ lazy val docs = project
   .enablePlugins(MicrositesPlugin)
   .settings(commonSettings)
   .settings(micrositeSettings)
-  .settings(libraryDependencies += "edu.berkeley.cs" %% "chisel-iotesters" % "1.3.1")
+  .settings(libraryDependencies += "edu.berkeley.cs" %% "chisel-iotesters" % "1.4.0-RC1")
   .settings(scalacOptions ++= (Seq("-Xsource:2.11")))
   .dependsOn(contributors)


### PR DESCRIPTION
- Build RC1 API docs
- Change snapshots to point at RC1
- Switch build.sbt to use RC1

The latter allows for future PRs to start updating the documentation
to 3.3.0.

This will allow #74 to work as-is with `mdoc` and without fake methods.