### PR TITLE
Bump API versions to 3.3.2/1.3.2

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,12 @@ firrtlTags = \
 	v1.2.2 \
 	v1.2.3 \
 	v1.2.4 \
-	v1.3.0
+	v1.2.5 \
+	v1.2.6 \
+	v1.2.7 \
+	v1.3.0 \
+	v1.3.1 \
+	v1.3.2
 chiselTags = \
 	v3.0.0 \
 	v3.0.1 \
@@ -48,7 +53,12 @@ chiselTags = \
 	v3.2.2 \
 	v3.2.3 \
 	v3.2.4 \
-	v3.3.0
+	v3.2.5 \
+	v3.2.6 \
+	v3.2.7 \
+	v3.3.0 \
+	v3.3.1 \
+	v3.3.2
 testersTags = \
 	v1.1.0 \
 	v1.1.1 \
@@ -69,7 +79,12 @@ testersTags = \
 	v1.3.2 \
 	v1.3.3 \
 	v1.3.4 \
-	v1.4.0
+	v1.3.5 \
+	v1.3.6 \
+	v1.3.7 \
+	v1.4.0 \
+	v1.4.1 \
+	v1.4.2
 treadleTags = \
 	v1.0.0 \
 	v1.0.1 \
@@ -82,7 +97,12 @@ treadleTags = \
 	v1.1.2 \
 	v1.1.3 \
 	v1.1.4 \
-	v1.2.0
+	v1.1.5 \
+	v1.1.6 \
+	v1.1.7 \
+	v1.2.0 \
+	v1.2.1 \
+	v1.2.2
 diagrammerTags = \
 	v1.0.0 \
 	v1.0.1 \
@@ -92,22 +112,32 @@ diagrammerTags = \
 	v1.1.2 \
 	v1.1.3 \
 	v1.1.4 \
-	v1.2.0
+	v1.1.5 \
+	v1.1.6 \
+	v1.1.7 \
+	v1.2.0 \
+	v1.2.1 \
+	v1.2.2
 chiseltestTags = \
 	v0.1.0 \
 	v0.1.1 \
 	v0.1.2 \
 	v0.1.3 \
 	v0.1.4 \
-	v0.2.0
+	v0.1.5 \
+	v0.1.6 \
+	v0.1.7 \
+	v0.2.0 \
+	v0.2.1 \
+	v0.2.2
 
 # Snapshot versions that will have their API published.
-firrtlSnapshot = v1.3.0
-chiselSnapshot = v3.3.0
-testersSnapshot = v1.4.0
-treadleSnapshot = v1.2.0
-diagrammerSnapshot = v1.2.0
-chiseltestSnapshot = v0.2.0
+firrtlSnapshot = v1.4-20200603-SNAPSHOT
+chiselSnapshot = v3.4-20200603-SNAPSHOT
+testersSnapshot = v1.5-20200603-SNAPSHOT
+treadleSnapshot = v1.3-20200603-SNAPSHOT
+diagrammerSnapshot = v1.3-20200603-SNAPSHOT
+chiseltestSnapshot = v0.3-20200603-SNAPSHOT
 
 # Get the latest version of some sequence of version strings
 # Usage: $(call getTags,$(foo))

--- a/docs/src/main/resources/microsite/data/menu.yml
+++ b/docs/src/main/resources/microsite/data/menu.yml
@@ -126,8 +126,18 @@ options:
     nested_options:
       - title: SNAPSHOT
         url: api/SNAPSHOT/
+      - title: 3.3.2
+        url: api/3.3.2/
+      - title: 3.3.1
+        url: api/3.3.1/
       - title: 3.3.0
         url: api/3.3.0/
+      - title: 3.2.7
+        url: api/3.2.7/
+      - title: 3.2.6
+        url: api/3.2.6/
+      - title: 3.2.5
+        url: api/3.2.5/
       - title: 3.2.4
         url: api/3.2.4/
       - title: 3.2.3
@@ -173,8 +183,18 @@ options:
     nested_options:
       - title: SNAPSHOT
         url: api/chisel-testers/SNAPSHOT/
+      - title: 1.4.2
+        url: api/chisel-testers/1.4.2/
+      - title: 1.4.1
+        url: api/chisel-testers/1.4.1/
       - title: 1.4.0
         url: api/chisel-testers/1.4.0/
+      - title: 1.3.7
+        url: api/chisel-testers/1.3.7/
+      - title: 1.3.6
+        url: api/chisel-testers/1.3.6/
+      - title: 1.3.5
+        url: api/chisel-testers/1.3.5/
       - title: 1.3.4
         url: api/chisel-testers/1.3.4/
       - title: 1.3.3
@@ -224,8 +244,22 @@ options:
     nested_options:
       - title: SNAPSHOT
         url: api/chiseltest/SNAPSHOT/
+      - title: 0.2.2
+        url: api/chiseltest/0.2.2/
+      - title: 0.2.1
+        url: api/chiseltest/0.2.1/
       - title: 0.2.0
         url: api/chiseltest/0.2.0/
+      - title: 0.1.7
+        url: api/chiseltest/0.1.7/
+      - title: 0.1.6
+        url: api/chiseltest/0.1.6/
+      - title: 0.1.5
+        url: api/chiseltest/0.1.5/
+      - title: 0.1.4
+        url: api/chiseltest/0.1.4/
+      - title: 0.1.3
+        url: api/chiseltest/0.1.3/
       - title: 0.1.2
         url: api/chiseltest/0.1.2/
       - title: 0.1.1
@@ -243,8 +277,18 @@ options:
     nested_options:
       - title: SNAPSHOT
         url: api/firrtl/SNAPSHOT/
+      - title: 1.3.2
+        url: api/firrtl/1.3.2/
+      - title: 1.3.1
+        url: api/firrtl/1.3.1/
       - title: 1.3.0
         url: api/firrtl/1.3.0/
+      - title: 1.2.7
+        url: api/firrtl/1.2.7/
+      - title: 1.2.6
+        url: api/firrtl/1.2.6/
+      - title: 1.2.5
+        url: api/firrtl/1.2.5/
       - title: 1.2.4
         url: api/firrtl/1.2.4/
       - title: 1.2.3
@@ -296,8 +340,18 @@ options:
     nested_options:
       - title: SNAPSHOT
         url: api/treadle/SNAPSHOT/
+      - title: 1.2.2
+        url: api/treadle/1.2.2/
+      - title: 1.2.1
+        url: api/treadle/1.2.1/
       - title: 1.2.0
         url: api/treadle/1.2.0/
+      - title: 1.1.7
+        url: api/treadle/1.1.7/
+      - title: 1.1.6
+        url: api/treadle/1.1.6/
+      - title: 1.1.5
+        url: api/treadle/1.1.5/
       - title: 1.1.4
         url: api/treadle/1.1.4/
       - title: 1.1.3
@@ -331,8 +385,18 @@ options:
     nested_options:
       - title: SNAPSHOT
         url: api/diagrammer/SNAPSHOT/
+      - title: 1.2.2
+        url: api/diagrammer/1.2.2/
+      - title: 1.2.1
+        url: api/diagrammer/1.2.1/
       - title: 1.2.0
         url: api/diagrammer/1.2.0/
+      - title: 1.1.7
+        url: api/diagrammer/1.1.7/
+      - title: 1.1.6
+        url: api/diagrammer/1.1.6/
+      - title: 1.1.5
+        url: api/diagrammer/1.1.5/
       - title: 1.1.4
         url: api/diagrammer/1.1.4/
       - title: 1.1.3


### PR DESCRIPTION
Bumps all API versions to include latest current release, previous backport releases (e.g., Chisel 3.2.7), and uses the latest snapshots.

I'll add a new API tarball release once all this is merged in.