### PR TITLE
Build FIRRTL Specification for each FIRRTL API Version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -38,7 +38,10 @@ jobs:
     - stage: "legacy chisel apis"
       script: make apis-chisel
     - stage: "legacy firrtl apis"
-      script: make apis-firrtl
+      script:
+        - sudo apt-get -qq update
+        - sudo apt-get install -y --no-install-recommends texlive-fonts-recommended texlive-latex-extra texlive-fonts-extra dvipng texlive-latex-recommended texlive-math-extra latexmk
+        - make apis-firrtl
     - stage: "legacy chisel-testers (iotesters) apis"
       script: make apis-chisel-testers
     - stage: "chiseltest (chisel-testers2) apis"

--- a/Makefile
+++ b/Makefile
@@ -190,16 +190,16 @@ api-copy = \
 # Build the site into the default directory (docs/target/site)
 all: docs/target/site/index.html
 
+# Targets to build FIRRTL specs
+specs-firrtl: $(firrtlTags:%=$(apis)/firrtl/%/spec.pdf) $(apis)/firrtl/$(firrtlSnapshot)/spec.pdf
+
 # Targets to build the legacy APIS of only a specific subproject
 apis-chisel: $(chiselTags:%=$(apis)/chisel3/%/index.html) $(apis)/chisel3/$(chiselSnapshot)/index.html
-apis-firrtl: $(firrtlTags:%=$(apis)/firrtl/%/index.html) $(apis)/firrtl/$(firrtlSnapshot)/index.html
+apis-firrtl: $(firrtlTags:%=$(apis)/firrtl/%/index.html) $(apis)/firrtl/$(firrtlSnapshot)/index.html specs-firrtl
 apis-chisel-testers: $(testersTags:%=$(apis)/chisel-testers/%/index.html) $(apis)/chisel-testers/$(testersSnapshot)/index.html
 apis-chiseltest: $(chiseltestTags:%=$(apis)/chiseltest/%/index.html)
 apis-treadle: $(treadleTags:%=$(apis)/treadle/%/index.html) $(apis)/treadle/$(treadleSnapshot)/index.html
 apis-diagrammer: $(diagrammerTags:%=$(apis)/diagrammer/%/index.html) $(apis)/diagrammer/$(diagrammerSnapshot)/index.html
-
-# Targets to build FIRRTL specs
-specs-firrtl: $(firrtlTags:%=$(apis)/firrtl/%/spec.pdf) $(apis)/firrtl/$(firrtlSnapshot)/spec.pdf
 
 # Remove the output of all build targets
 clean:

--- a/docs/src/main/resources/microsite/data/menu.yml
+++ b/docs/src/main/resources/microsite/data/menu.yml
@@ -321,6 +321,56 @@ options:
         url: api/firrtl/1.0.1/
       - title: 1.0.0
         url: api/firrtl/1.0.0/
+  - title: Specification
+    url: api/firrtl/latest/spec.pdf
+    menu_type: firrtl
+    nested_options:
+      - title: SNAPSHOT
+        url: api/firrtl/SNAPSHOT/spec.pdf
+      - title: 1.3.2
+        url: api/firrtl/1.3.2/spec.pdf
+      - title: 1.3.1
+        url: api/firrtl/1.3.1/spec.pdf
+      - title: 1.3.0
+        url: api/firrtl/1.3.0/spec.pdf
+      - title: 1.2.7
+        url: api/firrtl/1.2.7/spec.pdf
+      - title: 1.2.6
+        url: api/firrtl/1.2.6/spec.pdf
+      - title: 1.2.5
+        url: api/firrtl/1.2.5/spec.pdf
+      - title: 1.2.4
+        url: api/firrtl/1.2.4/spec.pdf
+      - title: 1.2.3
+        url: api/firrtl/1.2.3/spec.pdf
+      - title: 1.2.2
+        url: api/firrtl/1.2.2/spec.pdf
+      - title: 1.2.1
+        url: api/firrtl/1.2.1/spec.pdf
+      - title: 1.2.0
+        url: api/firrtl/1.2.0/spec.pdf
+      - title: 1.1.7
+        url: api/firrtl/1.1.7/spec.pdf
+      - title: 1.1.6
+        url: api/firrtl/1.1.6/spec.pdf
+      - title: 1.1.5
+        url: api/firrtl/1.1.5/spec.pdf
+      - title: 1.1.4
+        url: api/firrtl/1.1.4/spec.pdf
+      - title: 1.1.3
+        url: api/firrtl/1.1.3/spec.pdf
+      - title: 1.1.2
+        url: api/firrtl/1.1.2/spec.pdf
+      - title: 1.1.1
+        url: api/firrtl/1.1.1/spec.pdf
+      - title: 1.1.0
+        url: api/firrtl/1.1.0/spec.pdf
+      - title: 1.0.2
+        url: api/firrtl/1.0.2/spec.pdf
+      - title: 1.0.1
+        url: api/firrtl/1.0.1/spec.pdf
+      - title: 1.0.0
+        url: api/firrtl/1.0.0/spec.pdf
 
   # Treadle Site
   - title: Treadle

--- a/scripts/build-firrtl-spec.sh
+++ b/scripts/build-firrtl-spec.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+
+# Force pdflatex to set the /date based on the date at which the
+# current commit was authored. This lets you build an old version of
+# the FIRRTL specification, but keep historical dates.
+AUTHOR_EPOCH=`git log --pretty=format:"%at"`
+export SOURCE_DATE_EPOCH=$AUTHOR_EPOCH FORCE_SOURCE_DATE=1
+
+# Build the FIRRTL spec, using a Makefile if one exists. Otherwise,
+# use latexmk to build it (using latexmk should be slightly more
+# efficient than a blind 3x run of pdflatex).
+if [ -f Makefile ]; then
+  make
+else
+  latexmk -pdf spec.tex
+fi


### PR DESCRIPTION
Modify the Makefile to copy the FIRRTL spec PDF file into the API documentation directory. If the FIRRTL spec PDF does not exist (this has always historically been committed in the repo, so this shouldn't currently happen) then the spec is rebuilt using pdflatex.

Travis is then updated to install the TeX Live package (same as for [riscv/riscv-isa-manual](https://github.com/riscv/riscv-isa-manual/blob/d08e29e238c9cff1e4ef63389e1f1e00bff333ad/.travis.yml#L3) with the addition of the `texlive-science` package) as the Makefile now needs `pdflatex` to be on the `$PATH`.

You can see this in the following screenshots.

This shows the new FIRRTL page. I've scrolled on the wall to the bottom on the left pane and am hovering over the 1.0.0 spec.

![2020-07-15-13:19:11](https://user-images.githubusercontent.com/1018530/87575471-f8874080-c69d-11ea-9513-6c8423691fc7.png)

The latest spec link is also shown here:

![2020-07-15-13:19:45](https://user-images.githubusercontent.com/1018530/87575581-1e144a00-c69e-11ea-96a6-90971b51df1d.png)

If I then open these up (which for me downloads them and opens them up), I have two versions of the spec on the right. Latest is top and 1.0.0 is bottom:

![2020-07-15-13:20:18](https://user-images.githubusercontent.com/1018530/87575645-34baa100-c69e-11ea-929b-f6f42cf562a8.png)
