### PR TITLE
Add 3.4.0 release API

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,7 +34,8 @@ firrtlTags = \
 	v1.2.7 \
 	v1.3.0 \
 	v1.3.1 \
-	v1.3.2
+	v1.3.2 \
+	v1.4.0
 chiselTags = \
 	v3.0.0 \
 	v3.0.1 \
@@ -58,7 +59,8 @@ chiselTags = \
 	v3.2.7 \
 	v3.3.0 \
 	v3.3.1 \
-	v3.3.2
+	v3.3.2 \
+	v3.4.0
 testersTags = \
 	v1.1.0 \
 	v1.1.1 \
@@ -84,7 +86,8 @@ testersTags = \
 	v1.3.7 \
 	v1.4.0 \
 	v1.4.1 \
-	v1.4.2
+	v1.4.2 \
+	v1.5.0
 treadleTags = \
 	v1.0.0 \
 	v1.0.1 \
@@ -102,7 +105,8 @@ treadleTags = \
 	v1.1.7 \
 	v1.2.0 \
 	v1.2.1 \
-	v1.2.2
+	v1.2.2 \
+	v1.3.0
 diagrammerTags = \
 	v1.0.0 \
 	v1.0.1 \
@@ -117,7 +121,8 @@ diagrammerTags = \
 	v1.1.7 \
 	v1.2.0 \
 	v1.2.1 \
-	v1.2.2
+	v1.2.2 \
+	v1.3.0
 chiseltestTags = \
 	v0.1.0 \
 	v0.1.1 \
@@ -129,15 +134,15 @@ chiseltestTags = \
 	v0.1.7 \
 	v0.2.0 \
 	v0.2.1 \
-	v0.2.2
+	v0.3.0
 
 # Snapshot versions that will have their API published.
-firrtlSnapshot = v1.4.0-RC3
-chiselSnapshot = v3.4.0-RC3
-testersSnapshot = v1.5.0-RC3
-treadleSnapshot = v1.3.0-RC3
-diagrammerSnapshot = v1.3.0-RC3
-chiseltestSnapshot = v0.3.0-RC3
+firrtlSnapshot = v1.4.0
+chiselSnapshot = v3.4.0
+testersSnapshot = v1.5.0
+treadleSnapshot = v1.3.0
+diagrammerSnapshot = v1.3.0
+chiseltestSnapshot = v0.3.0
 
 # Get the latest version of some sequence of version strings
 # Usage: $(call getTags,$(foo))

--- a/docs/src/main/resources/microsite/data/menu.yml
+++ b/docs/src/main/resources/microsite/data/menu.yml
@@ -128,6 +128,8 @@ options:
     nested_options:
       - title: SNAPSHOT
         url: api/SNAPSHOT/
+      - title: 3.4.0
+        url: api/3.4.0/
       - title: 3.3.2
         url: api/3.3.2/
       - title: 3.3.1
@@ -185,6 +187,8 @@ options:
     nested_options:
       - title: SNAPSHOT
         url: api/chisel-testers/SNAPSHOT/
+      - title: 1.5.0
+        url: api/chisel-testers/1.5.0/
       - title: 1.4.2
         url: api/chisel-testers/1.4.2/
       - title: 1.4.1
@@ -246,6 +250,8 @@ options:
     nested_options:
       - title: SNAPSHOT
         url: api/chiseltest/SNAPSHOT/
+      - title: 0.3.0
+        url: api/chiseltest/0.3.0/
       - title: 0.2.2
         url: api/chiseltest/0.2.2/
       - title: 0.2.1
@@ -279,6 +285,8 @@ options:
     nested_options:
       - title: SNAPSHOT
         url: api/firrtl/SNAPSHOT/
+      - title: 1.4.0
+        url: api/firrtl/1.4.0/
       - title: 1.3.2
         url: api/firrtl/1.3.2/
       - title: 1.3.1
@@ -342,6 +350,8 @@ options:
     nested_options:
       - title: SNAPSHOT
         url: api/treadle/SNAPSHOT/
+      - title: 1.3.0
+        url: api/treadle/1.3.0/
       - title: 1.2.2
         url: api/treadle/1.2.2/
       - title: 1.2.1
@@ -387,6 +397,8 @@ options:
     nested_options:
       - title: SNAPSHOT
         url: api/diagrammer/SNAPSHOT/
+      - title: 1.3.0
+        url: api/diagrammer/1.3.0/
       - title: 1.2.2
         url: api/diagrammer/1.2.2/
       - title: 1.2.1


### PR DESCRIPTION
Adds latest (3.4.0 of Chisel, 1.4.0 of FIRRTL) release Scaladoc.