### PR TITLE
Fix the Appendix sections

### DIFF
--- a/docs/src/main/resources/microsite/data/menu.yml
+++ b/docs/src/main/resources/microsite/data/menu.yml
@@ -116,17 +116,17 @@ options:
         url: chisel3/docs/wiki-deprecated/reset.html
         menu_type: chisel3
         menu_section: reset
-      - title: Appendix
+  - title: Appendix
+    url: chisel3/docs/wiki-deprecated/chisel3-vs-chisel2.html
+    menu_type: chisel3
+    menu_section: appendix
+    nested_options:
+      - title: Chisel3 vs. Chisel2
         url: chisel3/docs/wiki-deprecated/chisel3-vs-chisel2.html
-        menu_type: chisel3
-        menu_section: appendix
-        nested_options:
-          - title: Chisel3 vs. Chisel2
-            url: chisel3/docs/wiki-deprecated/chisel3-vs-chisel2.html
-          - title: Experimental Features
-            url: chisel3/docs/wiki-deprecated/experimental-features.html
-          - title: Upgrading From Scala 2.11
-            url: chisel3/docs/wiki-deprecated/upgrading-from-scala-2-11.html
+      - title: Experimental Features
+        url: chisel3/docs/wiki-deprecated/experimental-features.html
+      - title: Upgrading From Scala 2.11
+        url: chisel3/docs/wiki-deprecated/upgrading-from-scala-2-11.html
   - title: Developers
     url: chisel3/docs/wiki-deprecated/developers.html
     menu_type: chisel3


### PR DESCRIPTION
sbt-microsites does not appear to support multiple levels of nesting, promote the Appendix out of the Wiki.

Take a look at the website today: https://www.chisel-lang.org/chisel3
`Appendix` has no subsections, there's no way to get to `Experimental Features` and `Upgrading From Scala 2.11`.

Ultimately we should also change the paths to match the new structure, but as that's in Chisel, it needs another PR.