### PR TITLE
Bump sbt-microsites to 1.3.0

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -64,7 +64,7 @@ jobs:
         uses: actions/setup-ruby@v1
       - name: Setup Jekyll
         run: |
-          gem install jekyll -v 3.8.5
+          gem install jekyll -v 4.2.0
           gem install jekyll-redirect-from
       - name: Download all built API docs
         uses: actions/download-artifact@v2

--- a/build.sbt
+++ b/build.sbt
@@ -18,7 +18,7 @@ val technologies: String =
 val determineContributors = taskKey[Unit]("determine contributors for subprojects")
 
 lazy val micrositeSettings = Seq(
-  scalaVersion := "2.12.6",
+  scalaVersion := "2.12.12",
   micrositeName := "Chisel/FIRRTL",
   micrositeDescription := "Chisel/FIRRTL\nHardware Compiler Framework",
   micrositeUrl := "https://www.chisel-lang.org",
@@ -35,7 +35,6 @@ lazy val micrositeSettings = Seq(
   micrositeDocumentationUrl := "api/latest/",
   micrositeDocumentationLabelDescription := "API Documentation",
   micrositeGitterChannelUrl := "freechipsproject/chisel3",
-  micrositeCompilingDocsTool := WithMdoc,
   mdocIn := file("docs/src/main/tut"),
   /* Copy markdown files from each of the submodules to build out the website:
    * - Chisel3 README becomes the landing page
@@ -69,11 +68,13 @@ lazy val micrositeSettings = Seq(
           "section" -> "diagrammer",
           "position" -> "6"))
   ),
+  micrositeExtraMdFilesOutput := resourceManaged.value / "main" / "jekyll",
   micrositeStaticDirectory := file("docs/target/site/api"),
   /* Known colors:
    *   - Chisel logo: #212560
    *   - FIRRTL logo: #136527
    */
+  micrositeTheme := "pattern",
   micrositePalette := Map(
     "brand-primary"     -> "#7B95A2",
     "brand-secondary"   -> "#1A3C79",
@@ -97,7 +98,7 @@ lazy val micrositeSettings = Seq(
     new FileFilter{
       def accept(f: File) = (ghpagesRepository.value / "CNAME").getCanonicalPath == f.getCanonicalPath
     } || "versions.html",
-  addCompilerPlugin("org.scalamacros" % "paradise" % "2.1.0" cross CrossVersion.full)
+  addCompilerPlugin("org.scalamacros" % "paradise" % "2.1.1" cross CrossVersion.full)
 )
 
 resolvers ++= Seq(

--- a/docs/src/main/tut/chisel3/index.md
+++ b/docs/src/main/tut/chisel3/index.md
@@ -2,7 +2,6 @@
 layout: docs
 title:  "Chisel3"
 section: "chisel3"
-position: 1
 ---
 
 This is a brief overview to the Chisel HDL.

--- a/docs/src/main/tut/index.md
+++ b/docs/src/main/tut/index.md
@@ -1,9 +1,0 @@
----
-layout: home
-title: "Chisel/FIRRTL"
-section: "home"
-technologies:
-- first: ["Scala", "Chisel is powered by Scala and brings all the power of object-oriented and functional programming to type-safe hardware design and generation."]
- - second: ["Chisel", "Chisel, the Chisel standard library, and Chisel testing infrastructure enable agile, expressive, and reusable hardware design methodologies."]
- - third: ["FIRRTL", "The FIRRTL circuit compiler starts after Chisel and enables backend (FPGA, ASIC, technology) specialization, automated circuit transformation, and Verilog generation."]
----

--- a/project/Contributors.scala
+++ b/project/Contributors.scala
@@ -6,19 +6,32 @@ object Contributors {
 
   import github4s.Github
   import github4s.Github._
-  import github4s.free.domain.User
-  import github4s.jvm.Implicits._
-  import scalaj.http.HttpResponse
+  import github4s.domain.User
+
+  import java.util.concurrent.Executors
+
+  import cats.effect.{Blocker, ContextShift, IO}
+  import org.http4s.client.{Client, JavaNetClientBuilder}
+
+  import scala.concurrent.ExecutionContext.global
+
+  val httpClient: Client[IO] = {
+    val blockingPool = Executors.newFixedThreadPool(5)
+    val blocker = Blocker.liftExecutorService(blockingPool)
+    implicit val cs: ContextShift[IO] = IO.contextShift(global)
+    JavaNetClientBuilder[IO](blocker).create // use BlazeClientBuilder for production use
+  }
 
   val token: Option[String] = sys.env.get("GITHUB4S_ACCESS_TOKEN")
 
   def contributors(repo: GitHubRepository): List[User] =
-    Github(token)
+    Github[IO](httpClient, token)
       .repos
       .listContributors(repo.owner, repo.repo)
-      .exec[cats.Id, HttpResponse[String]]() match {
+      .unsafeRunSync()
+      .result match {
         case Left(e) => throw new Exception(s"Unable to fetch contributors for ${repo.serialize}. Did you misspell it? Did the repository move?")
-        case Right(r) => r.result
+        case Right(r) => r
       }
 
   def contributorsMarkdown(contributors: Seq[User]): String =

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,1 +1,1 @@
-addSbtPlugin("com.47deg"  % "sbt-microsites" % "0.9.6")
+addSbtPlugin("com.47deg"  % "sbt-microsites" % "1.3.0")


### PR DESCRIPTION
There aren't any features this is taking advantage of, but we could look at the new theme. I'm largely wanting to do this to stay up to date because it looks like search is coming to sbt-microsites and I want to be able to use that.

Several changes were required:
* micrositeCompilingDocsTool removed in 1.3.0 (always mdoc)
* micrositeExtraMdFilesOutput seems to require specifically being set
  (maybe changed default?)
* micrositeTheme must be set, "pattern" matches old theme
* colliding index.md caused issue, but was unused so deleted
* Contributors.scala needed to be updated for changes to github4s
* "position" key should be only be present on markdown files that should
  be present as a link on the home page menu