### PR TITLE
Track stable branches of git submodules

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,18 +1,24 @@
 [submodule "chisel3"]
 	path = chisel3
 	url = https://github.com/freechipsproject/chisel3.git
+	branch = 3.4.x
 [submodule "chisel-testers"]
 	path = chisel-testers
 	url = https://github.com/freechipsproject/chisel-testers.git
+	branch = 1.5.x
 [submodule "firrtl"]
 	path = firrtl
 	url = https://github.com/freechipsproject/firrtl
+	branch = 1.4.x
 [submodule "treadle"]
 	path = treadle
 	url = https://github.com/freechipsproject/treadle
+	branch = 1.3.x
 [submodule "diagrammer"]
 	path = diagrammer
 	url = https://github.com/freechipsproject/diagrammer
+	branch = 1.3.x
 [submodule "chiseltest"]
 	path = chiseltest
 	url = https://github.com/ucb-bar/chisel-testers2
+	branch = 0.3.x


### PR DESCRIPTION
Feature of git I didn't realize existed, hoping that Dependabot will honor it. If it won't, we can write a custom action to do this.