### PR TITLE
Link to chisel3 docs instead of API docs

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -32,9 +32,10 @@ lazy val micrositeSettings = Seq(
   micrositeGithubRepo := "chisel3",
   micrositeGithubLinks := false,
   micrositeShareOnSocial := false,
-  micrositeDocumentationUrl := "api/latest/",
-  micrositeDocumentationLabelDescription := "API Documentation",
+  micrositeDocumentationUrl := "chisel3/",
+  micrositeDocumentationLabelDescription := "Documentation",
   micrositeGitterChannelUrl := "freechipsproject/chisel3",
+  micrositeHighlightLanguages ++= Seq("verilog"),
   mdocIn := file("docs/src/main/tut"),
   /* Copy markdown files from each of the submodules to build out the website:
    * - Chisel3 README becomes the landing page


### PR DESCRIPTION
The prose documentation and tutorials is way more important for most
visitors of the website than the API Docs. Change the special top-right
link to be to the chisel3 docs instead of the API docs.

Also, turn on syntax highlighting for Verilog. (I came across this while perusing the sbt-microsites docs)