### PR TITLE
Add migrating-from-iotesters redirect

### DIFF
--- a/docs/src/main/tut/chiseltest/migrating-from-iotesters.md
+++ b/docs/src/main/tut/chiseltest/migrating-from-iotesters.md
@@ -1,0 +1,11 @@
+---
+redirect_to: chiseltest/#migrating-from-chisel-testers--iotesters
+---
+<!---
+
+********** DO NOT DELETE **********
+This is used in deprecation warnings in chisel-iotesters 2.5 published artifacts
+
+https://www.chisel-lang.org/chiseltest/migrating-from-iotesters
+
+--->


### PR DESCRIPTION
This currently redirects to the index of the chiseltest page which is a
rendering of the chiseltest README. This provides a stable link that we
can use in deprecation warnings in chisel-iotesters that we can then
update into a richer document while keeping the link alive.

This will enable me to use https://www.chisel-lang.org/chiseltest/migrating-from-iotesters as a stable URL in the deprecation warnings in https://github.com/freechipsproject/chisel-testers/pull/326.