### PR TITLE
Use javadoc.io for all ScalaDoc

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        project: [chisel3, firrtl, chisel-testers, chiseltest, treadle, diagrammer]
+        project: [chisel3]
 
     steps:
       - name: Checkout

--- a/Makefile
+++ b/Makefile
@@ -17,52 +17,10 @@ www-src = \
 	treadle/README.md \
 	diagrammer/README.md
 
-firrtlTags = \
-	v1.0.2 \
-	v1.1.7 \
-	v1.2.8 \
-	v1.3.3 \
-	v1.4.4 \
-	v1.5.3
 chiselTags = \
-	v3.0.2 \
-	v3.1.8 \
 	v3.2.8 \
 	v3.3.3 \
-	v3.4.4 \
-	v3.5.3
-testersTags = \
-	v1.1.2 \
-	v1.2.10 \
-	v1.3.8 \
-	v1.4.3 \
-	v1.5.4 \
-	v2.5.3
-treadleTags = \
-	v1.0.5 \
-	v1.1.8 \
-	v1.2.3 \
-	v1.3.3 \
-	v1.5.3
-diagrammerTags = \
-	v1.0.2 \
-	v1.1.8 \
-	v1.2.3 \
-	v1.3.3 \
-	v1.5.3
-chiseltestTags = \
-	v0.1.7 \
-	v0.2.3 \
-	v0.3.3 \
-	v0.5.3
-
-# Snapshot versions that will have their API published.
-firrtlSnapshot = v1.5.3
-chiselSnapshot = v3.5.3
-testersSnapshot = v2.5.3
-treadleSnapshot = v1.5.3
-diagrammerSnapshot = v1.5.3
-chiseltestSnapshot = v0.5.3
+	v3.4.4
 
 # Get the latest version of some sequence of version strings
 # Usage: $(call getTags,$(foo))
@@ -70,37 +28,14 @@ define latest
 $(shell echo $(1) | tr " " "\n" | sort -Vr | head -n1 | sed 's/^v//')
 endef
 
-# The "latest" version that will be pointed to by, e.g., 'api/latest'
-# or 'api/firrtl/latest'.
-firrtlLatest = $(call latest,$(firrtlTags))
-chiselLatest = $(call latest,$(chiselTags))
-testersLatest = $(call latest,$(testersTags))
-treadleLatest = $(call latest,$(treadleTags))
-diagrammerLatest = $(call latest,$(diagrammerTags))
-chiseltestLatest = $(call latest,$(chiseltestTags))
-
 # If NO_API is set, these variables will be supressed,
 # this makes building the website *much* faster for local development
 ifeq ($(NO_API),)
-api-latest = \
-	docs/target/site/api/latest \
-	docs/target/site/api/firrtl/latest \
-	docs/target/site/api/chisel-testers/latest \
-	docs/target/site/api/treadle/latest \
-	docs/target/site/api/diagrammer/latest \
-	docs/target/site/api/chiseltest/latest
-
-api-copy = \
-	$(chiselTags:v%=docs/target/site/api/%/index.html) docs/target/site/api/SNAPSHOT/index.html \
-	$(firrtlTags:v%=docs/target/site/api/firrtl/%/index.html) docs/target/site/api/firrtl/SNAPSHOT/index.html \
-	$(testersTags:v%=docs/target/site/api/chisel-testers/%/index.html) docs/target/site/api/chisel-testers/SNAPSHOT/index.html \
-	$(chiseltestTags:v%=docs/target/site/api/chiseltest/%/index.html) docs/target/site/api/chiseltest/SNAPSHOT/index.html \
-	$(treadleTags:v%=docs/target/site/api/treadle/%/index.html) docs/target/site/api/treadle/SNAPSHOT/index.html \
-	$(diagrammerTags:v%=docs/target/site/api/diagrammer/%/index.html) docs/target/site/api/diagrammer/SNAPSHOT/index.html
+api-copy = $(chiselTags:v%=docs/target/site/api/%/index.html)
 endif
 
 .PHONY: all clean mrproper publish serve \
-	apis-chisel3 apis-firrtl apis-chisel-testers apis-treadle apis-diagrammer apis-chiseltest
+	apis-chisel3
 .PRECIOUS: \
 	$(subprojects)/chisel3/%/.git $(subprojects)/chisel3/%/target/scala-$(scalaVersion)/unidoc/index.html \
 	$(subprojects)/firrtl/%/.git $(subprojects)/firrtl/%/target/scala-$(scalaVersion)/unidoc/index.html \
@@ -108,9 +43,8 @@ endif
 	$(subprojects)/chiseltest/%/.git $(subprojects)/chiseltest/%/target/scala-$(scalaVersion)/api/index.html \
 	$(subprojects)/treadle/%/.git $(subprojects)/treadle/%/target/scala-$(scalaVersion)/api/index.html \
 	$(subprojects)/diagrammer/%/.git $(subprojects)/diagrammer/%/target/scala-$(scalaVersion)/api/index.html \
-	$(apis)/chisel3/v%/index.html $(apis)/firrtl/%/index.html $(apis)/chisel-testers/%/index.html \
-	$(apis)/chiseltest/%/index.html $(apis)/treadle/%/index.html $(apis)/diagrammer/%/index.html \
-	docs/target/site/api/%/ docs/target/site/api/firrtl/%/ docs/target/site/api/chisel-testers/%/
+	$(apis)/chisel3/v%/index.html \
+	docs/target/site/api/%/ docs/target/site/api/firrtl/%/ docs/target/site/api/chisel-testers/%/ \
 	docs/target/site/api/chiseltest/%/ docs/target/site/api/treadle/%/ docs/target/site/api/diagrammer/%/ \
 	$(apis)/%/
 
@@ -118,12 +52,7 @@ endif
 all: docs/target/site/index.html
 
 # Targets to build the legacy APIS of only a specific subproject
-apis-chisel3: $(chiselTags:%=$(apis)/chisel3/%/index.html) $(apis)/chisel3/$(chiselSnapshot)/index.html $(apis)/chisel3/master/index.html
-apis-firrtl: $(firrtlTags:%=$(apis)/firrtl/%/index.html) $(apis)/firrtl/$(firrtlSnapshot)/index.html
-apis-chisel-testers: $(testersTags:%=$(apis)/chisel-testers/%/index.html) $(apis)/chisel-testers/$(testersSnapshot)/index.html
-apis-chiseltest: $(chiseltestTags:%=$(apis)/chiseltest/%/index.html)
-apis-treadle: $(treadleTags:%=$(apis)/treadle/%/index.html) $(apis)/treadle/$(treadleSnapshot)/index.html
-apis-diagrammer: $(diagrammerTags:%=$(apis)/diagrammer/%/index.html) $(apis)/diagrammer/$(diagrammerSnapshot)/index.html
+apis-chisel3: $(chiselTags:%=$(apis)/chisel3/%/index.html)
 
 # Remove the output of all build targets
 clean:
@@ -149,26 +78,6 @@ docs/target/site/index.html: build.sbt docs/src/main/tut/contributors.md $(www-s
 docs/src/main/tut/contributors.md: build.sbt
 	sbt contributors/determineContributors
 
-# Copy built API into site
-docs/target/site/api/latest: docs/target/site/api/$(chiselLatest)/index.html
-	rm -f $@
-	ln -s $(chiselLatest) $@
-docs/target/site/api/firrtl/latest: docs/target/site/api/firrtl/$(firrtlLatest)/index.html
-	rm -f $@
-	ln -s $(firrtlLatest) $@
-docs/target/site/api/treadle/latest: docs/target/site/api/treadle/$(treadleLatest)/index.html
-	rm -f $@
-	ln -s $(treadleLatest) $@
-docs/target/site/api/chisel-testers/latest: docs/target/site/api/chisel-testers/$(testersLatest)/index.html
-	rm -f $@
-	ln -s $(testersLatest) $@
-docs/target/site/api/diagrammer/latest: docs/target/site/api/diagrammer/$(diagrammerLatest)/index.html
-	rm -f $@
-	ln -s $(diagrammerLatest) $@
-docs/target/site/api/chiseltest/latest: docs/target/site/api/chiseltest/$(chiseltestLatest)/index.html
-	rm -f $@
-	ln -s $(chiseltestLatest) $@
-
 # Build API for a subproject with a specific tag. Each build rule is
 # specialized by the type of documentation to build (either
 # scaladoc/"sbt doc" or unidoc/"sbt unidoc"). The version of Scala in
@@ -178,52 +87,13 @@ docs/target/site/api/chiseltest/latest: docs/target/site/api/chiseltest/$(chisel
 $(apis)/chisel3/%/index.html: $(subprojects)/chisel3/%/.git | $(apis)/chisel3/%/
 	(cd $(subprojects)/chisel3/$* && sbt unidoc)
 	find $(<D) -type d -name unidoc -exec cp -r '{}'/. $(@D) ';'
-$(apis)/firrtl/%/index.html: $(subprojects)/firrtl/%/.git | $(apis)/firrtl/%/
-	(cd $(subprojects)/firrtl/$* && sbt unidoc)
-	find $(<D) -type d -name unidoc -exec cp -r '{}'/. $(@D) ';'
-$(apis)/chisel-testers/%/index.html: $(subprojects)/chisel-testers/%/.git | $(apis)/chisel-testers/%/
-	(cd $(subprojects)/chisel-testers/$* && sbt doc)
-	find $(<D) -type d -name api -exec cp -r '{}'/. $(@D) ';'
-$(apis)/treadle/%/index.html: $(subprojects)/treadle/%/.git | $(apis)/treadle/%/
-	(cd $(subprojects)/treadle/$* && sbt doc)
-	find $(<D) -type d -name api -exec cp -r '{}'/. $(@D) ';'
-$(apis)/diagrammer/%/index.html: $(subprojects)/diagrammer/%/.git | $(apis)/diagrammer/%/
-	(cd $(subprojects)/diagrammer/$* && sbt doc)
-	find $(<D) -type d -name api -exec cp -r '{}'/. $(@D) ';'
-$(apis)/chiseltest/%/index.html: $(subprojects)/chiseltest/%/.git | $(apis)/chiseltest/%/
-	(cd $(subprojects)/chiseltest/$* && sbt doc)
-	find $(<D) -type d -name api -exec cp -r '{}'/. $(@D) ';'
 
 # Build docs in subproject with a specific tag.
 docs/src/main/tut/chisel3/docs: chisel3/.git $(www-docs)
 	(cd chisel3 && sbt docs/mdoc && cp -r docs/generated ../docs/src/main/tut/chisel3/docs)
 
-# Copy *SNAPSHOT* API of subprojects into API directory
-docs/target/site/api/SNAPSHOT/index.html: $(apis)/chisel3/$(chiselSnapshot)/index.html | docs/target/site/api/SNAPSHOT/
-	cp -r $(<D)/. $(@D)
-docs/target/site/api/firrtl/SNAPSHOT/index.html: $(apis)/firrtl/$(firrtlSnapshot)/index.html | docs/target/site/api/firrtl/SNAPSHOT/
-	cp -r $(<D)/. $(@D)
-docs/target/site/api/chisel-testers/SNAPSHOT/index.html: $(apis)/chisel-testers/$(testersSnapshot)/index.html | docs/target/site/api/chisel-testers/SNAPSHOT/
-	cp -r $(<D)/. $(@D)
-docs/target/site/api/treadle/SNAPSHOT/index.html: $(apis)/treadle/$(treadleSnapshot)/index.html | docs/target/site/api/treadle/SNAPSHOT/
-	cp -r $(<D)/. $(@D)
-docs/target/site/api/diagrammer/SNAPSHOT/index.html: $(apis)/diagrammer/$(diagrammerSnapshot)/index.html | docs/target/site/api/diagrammer/SNAPSHOT/
-	cp -r $(<D)/. $(@D)
-docs/target/site/api/chiseltest/SNAPSHOT/index.html: $(apis)/chiseltest/$(chiseltestSnapshot)/index.html | docs/target/site/api/chiseltest/SNAPSHOT/
-	cp -r $(<D)/. $(@D)
-
 # Copy *old* API of subprojects from API directory into website
 docs/target/site/api/%/index.html: $(apis)/chisel3/v%/index.html | docs/target/site/api/%/
-	cp -r $(<D)/. $(@D)
-docs/target/site/api/firrtl/%/index.html: $(apis)/firrtl/v%/index.html | docs/target/site/api/firrtl/%/
-	cp -r $(<D)/. $(@D)
-docs/target/site/api/chisel-testers/%/index.html: $(apis)/chisel-testers/v%/index.html | docs/target/site/api/chisel-testers/%/
-	cp -r $(<D)/. $(@D)
-docs/target/site/api/treadle/%/index.html: $(apis)/treadle/v%/index.html | docs/target/site/api/treadle/%/
-	cp -r $(<D)/. $(@D)
-docs/target/site/api/diagrammer/%/index.html: $(apis)/diagrammer/v%/index.html | docs/target/site/api/diagrammer/%/
-	cp -r $(<D)/. $(@D)
-docs/target/site/api/chiseltest/%/index.html: $(apis)/chiseltest/v%/index.html | docs/target/site/api/chiseltest/%/
 	cp -r $(<D)/. $(@D)
 
 # Utilities to either fetch submodules or create directories

--- a/docs/src/main/resources/microsite/data/menu.yml
+++ b/docs/src/main/resources/microsite/data/menu.yml
@@ -179,9 +179,9 @@ options:
     menu_type: chisel3
     nested_options:
       - title: Latest
-        url: api/latest/
+        url: api/chisel3/latest/
       - title: 3.5
-        url: api/3.5.3/
+        url: api/chisel3/3.5/
       - title: 3.4
         url: api/3.4.4/
       - title: 3.3
@@ -198,15 +198,15 @@ options:
     menu_type: chisel-testers
     nested_options:
       - title: Latest
-        url: api/chisel-testers/latest/
+        url: api/chisel-testers/latest
       - title: 2.5
-        url: api/chisel-testers/2.5.3/
+        url: api/chisel-testers/2.5
       - title: 1.5
-        url: api/chisel-testers/1.5.3/
+        url: api/chisel-testers/1.5
       - title: 1.4
-        url: api/chisel-testers/1.4.3/
+        url: api/chisel-testers/1.4
       - title: 1.3
-        url: api/chisel-testers/1.3.8/
+        url: api/chisel-testers/1.3
 
   # Chisel Test (chisel-testers2)
   - title: ChiselTest
@@ -217,15 +217,15 @@ options:
     menu_type: chiseltest
     nested_options:
       - title: Latest
-        url: api/chiseltest/latest/
+        url: api/chiseltest/latest
       - title: 0.5
-        url: api/chiseltest/0.5.3/
+        url: api/chiseltest/0.5
       - title: 0.3
-        url: api/chiseltest/0.3.4/
+        url: api/chiseltest/0.3
       - title: 0.2
-        url: api/chiseltest/0.2.3/
+        url: api/chiseltest/0.2
       - title: 0.1
-        url: api/chiseltest/0.1.8/
+        url: api/chiseltest/0.1
 
   # FIRRTL Site
   - title: FIRRTL
@@ -236,15 +236,15 @@ options:
     menu_type: firrtl
     nested_options:
       - title: Latest
-        url: api/firrtl/latest/
+        url: api/firrtl/latest
       - title: 1.5
-        url: api/firrtl/1.5.3/
+        url: api/firrtl/1.5
       - title: 1.4
-        url: api/firrtl/1.4.4/
+        url: api/firrtl/1.4
       - title: 1.3
-        url: api/firrtl/1.3.3/
+        url: api/firrtl/1.3
       - title: 1.2
-        url: api/firrtl/1.2.8/
+        url: api/firrtl/1.2
 
   # Treadle Site
   - title: Treadle
@@ -263,15 +263,15 @@ options:
     menu_type: treadle
     nested_options:
       - title: Latest
-        url: api/treadle/latest/
+        url: api/treadle/latest
       - title: 1.5
-        url: api/treadle/1.5.3/
+        url: api/treadle/1.5
       - title: 1.3
-        url: api/treadle/1.3.4/
+        url: api/treadle/1.3
       - title: 1.2
-        url: api/treadle/1.2.3/
+        url: api/treadle/1.2
       - title: 1.1
-        url: api/treadle/1.1.8/
+        url: api/treadle/1.1
 
   # Diagrammer Site
   - title: Diagrammer
@@ -284,10 +284,10 @@ options:
       - title: Latest
         url: api/diagrammer/latest
       - title: 1.5
-        url: api/diagrammer/1.5.3/
+        url: api/diagrammer/1.5
       - title: 1.3
-        url: api/diagrammer/1.3.4/
+        url: api/diagrammer/1.3
       - title: 1.2
-        url: api/diagrammer/1.2.3/
+        url: api/diagrammer/1.2
       - title: 1.1
-        url: api/diagrammer/1.1.8/
+        url: api/diagrammer/1.1

--- a/docs/src/main/tut/api/chisel-testers/1.3/index.md
+++ b/docs/src/main/tut/api/chisel-testers/1.3/index.md
@@ -1,0 +1,4 @@
+---
+redirect_to: https://javadoc.io/doc/edu.berkeley.cs/chisel-iotesters_2.12/1.3
+---
+

--- a/docs/src/main/tut/api/chisel-testers/1.4/index.md
+++ b/docs/src/main/tut/api/chisel-testers/1.4/index.md
@@ -1,0 +1,4 @@
+---
+redirect_to: https://javadoc.io/doc/edu.berkeley.cs/chisel-iotesters_2.12/1.4
+---
+

--- a/docs/src/main/tut/api/chisel-testers/1.5/index.md
+++ b/docs/src/main/tut/api/chisel-testers/1.5/index.md
@@ -1,0 +1,4 @@
+---
+redirect_to: https://javadoc.io/doc/edu.berkeley.cs/chisel-iotesters_2.12/1.5
+---
+

--- a/docs/src/main/tut/api/chisel-testers/2.5/index.md
+++ b/docs/src/main/tut/api/chisel-testers/2.5/index.md
@@ -1,0 +1,4 @@
+---
+redirect_to: https://javadoc.io/doc/edu.berkeley.cs/chisel-iotesters_2.13/2.5
+---
+

--- a/docs/src/main/tut/api/chisel-testers/index.md
+++ b/docs/src/main/tut/api/chisel-testers/index.md
@@ -9,10 +9,8 @@ section: "chisel-testers"
 We host only the latest minor version for each major version to keep the size down for website hosting.
 Please see the page about [Versioning](../../chisel3/docs/appendix/versioning.html) for more information about major and minor versioning and binary compatibility.
 
-* [2.5.3](2.5.3/)
-* [1.5.4](1.5.4/)
-* [1.4.3](1.4.3/)
-* [1.3.8](1.3.8/)
-* [1.2.10](1.2.10/)
-* [1.1.2](1.1.2/)
+* [2.5](2.5/)
+* [1.5](1.5/)
+* [1.4](1.4/)
+* [1.3](1.3/)
 

--- a/docs/src/main/tut/api/chisel-testers/latest/index.md
+++ b/docs/src/main/tut/api/chisel-testers/latest/index.md
@@ -1,0 +1,4 @@
+---
+redirect_to: https://javadoc.io/doc/edu.berkeley.cs/chisel-iotesters_2.13
+---
+

--- a/docs/src/main/tut/api/chisel3/3.5/index.md
+++ b/docs/src/main/tut/api/chisel3/3.5/index.md
@@ -1,0 +1,4 @@
+---
+redirect_to: https://javadoc.io/doc/edu.berkeley.cs/chisel3_2.13/3.5
+---
+

--- a/docs/src/main/tut/api/chisel3/latest/index.md
+++ b/docs/src/main/tut/api/chisel3/latest/index.md
@@ -1,0 +1,4 @@
+---
+redirect_to: https://javadoc.io/doc/edu.berkeley.cs/chisel3_2.13
+---
+

--- a/docs/src/main/tut/api/chiseltest/0.1/index.md
+++ b/docs/src/main/tut/api/chiseltest/0.1/index.md
@@ -1,0 +1,4 @@
+---
+redirect_to: https://javadoc.io/doc/edu.berkeley.cs/chiseltest_2.12/0.1
+---
+

--- a/docs/src/main/tut/api/chiseltest/0.2/index.md
+++ b/docs/src/main/tut/api/chiseltest/0.2/index.md
@@ -1,0 +1,4 @@
+---
+redirect_to: https://javadoc.io/doc/edu.berkeley.cs/chiseltest_2.12/0.2
+---
+

--- a/docs/src/main/tut/api/chiseltest/0.3/index.md
+++ b/docs/src/main/tut/api/chiseltest/0.3/index.md
@@ -1,0 +1,4 @@
+---
+redirect_to: https://javadoc.io/doc/edu.berkeley.cs/chiseltest_2.12/0.3
+---
+

--- a/docs/src/main/tut/api/chiseltest/0.5/index.md
+++ b/docs/src/main/tut/api/chiseltest/0.5/index.md
@@ -1,0 +1,4 @@
+---
+redirect_to: https://javadoc.io/doc/edu.berkeley.cs/chiseltest_2.13/0.5
+---
+

--- a/docs/src/main/tut/api/chiseltest/index.md
+++ b/docs/src/main/tut/api/chiseltest/index.md
@@ -9,8 +9,8 @@ section: "chiseltest"
 We host only the latest minor version for each major version to keep the size down for website hosting.
 Please see the page about [Versioning](../../chisel3/docs/appendix/versioning.html) for more information about major and minor versioning and binary compatibility.
 
-* [0.5.3](0.5.3/)
-* [0.3.4](0.3.4/)
-* [0.2.3](0.2.3/)
-* [0.1.8](0.1.7/)
+* [0.5](0.5/)
+* [0.3](0.3/)
+* [0.2](0.2/)
+* [0.1](0.1/)
 

--- a/docs/src/main/tut/api/chiseltest/latest/index.md
+++ b/docs/src/main/tut/api/chiseltest/latest/index.md
@@ -1,0 +1,4 @@
+---
+redirect_to: https://javadoc.io/doc/edu.berkeley.cs/chiseltest_2.13
+---
+

--- a/docs/src/main/tut/api/diagrammer/1.1/index.md
+++ b/docs/src/main/tut/api/diagrammer/1.1/index.md
@@ -1,0 +1,4 @@
+---
+redirect_to: https://javadoc.io/doc/edu.berkeley.cs/firrtl-diagrammer_2.12/1.1
+---
+

--- a/docs/src/main/tut/api/diagrammer/1.2/index.md
+++ b/docs/src/main/tut/api/diagrammer/1.2/index.md
@@ -1,0 +1,4 @@
+---
+redirect_to: https://javadoc.io/doc/edu.berkeley.cs/firrtl-diagrammer_2.12/1.2
+---
+

--- a/docs/src/main/tut/api/diagrammer/1.3/index.md
+++ b/docs/src/main/tut/api/diagrammer/1.3/index.md
@@ -1,0 +1,4 @@
+---
+redirect_to: https://javadoc.io/doc/edu.berkeley.cs/firrtl-diagrammer_2.12/1.3
+---
+

--- a/docs/src/main/tut/api/diagrammer/1.5/index.md
+++ b/docs/src/main/tut/api/diagrammer/1.5/index.md
@@ -1,0 +1,4 @@
+---
+redirect_to: https://javadoc.io/doc/edu.berkeley.cs/firrtl-diagrammer_2.13/1.5
+---
+

--- a/docs/src/main/tut/api/diagrammer/index.md
+++ b/docs/src/main/tut/api/diagrammer/index.md
@@ -9,9 +9,8 @@ section: "diagrammer"
 We host only the latest minor version for each major version to keep the size down for website hosting.
 Please see the page about [Versioning](../../chisel3/docs/appendix/versioning.html) for more information about major and minor versioning and binary compatibility.
 
-* [1.5.3](1.5.3/)
-* [1.3.4](1.3.4/)
-* [1.2.3](1.2.3/)
-* [1.1.8](1.1.8/)
-* [1.0.2](1.0.2/)
+* [1.5](1.5/)
+* [1.3](1.3/)
+* [1.2](1.2/)
+* [1.1](1.1/)
 

--- a/docs/src/main/tut/api/diagrammer/latest/index.md
+++ b/docs/src/main/tut/api/diagrammer/latest/index.md
@@ -1,0 +1,4 @@
+---
+redirect_to: https://javadoc.io/doc/edu.berkeley.cs/firrtl-diagrammer_2.13
+---
+

--- a/docs/src/main/tut/api/firrtl/1.2/index.md
+++ b/docs/src/main/tut/api/firrtl/1.2/index.md
@@ -1,0 +1,4 @@
+---
+redirect_to: https://javadoc.io/doc/edu.berkeley.cs/firrtl_2.12/1.2
+---
+

--- a/docs/src/main/tut/api/firrtl/1.3/index.md
+++ b/docs/src/main/tut/api/firrtl/1.3/index.md
@@ -1,0 +1,4 @@
+---
+redirect_to: https://javadoc.io/doc/edu.berkeley.cs/firrtl_2.12/1.3
+---
+

--- a/docs/src/main/tut/api/firrtl/1.4/index.md
+++ b/docs/src/main/tut/api/firrtl/1.4/index.md
@@ -1,0 +1,4 @@
+---
+redirect_to: https://javadoc.io/doc/edu.berkeley.cs/firrtl_2.12/1.4
+---
+

--- a/docs/src/main/tut/api/firrtl/1.5/index.md
+++ b/docs/src/main/tut/api/firrtl/1.5/index.md
@@ -1,0 +1,4 @@
+---
+redirect_to: https://javadoc.io/doc/edu.berkeley.cs/firrtl_2.13/1.5
+---
+

--- a/docs/src/main/tut/api/firrtl/index.md
+++ b/docs/src/main/tut/api/firrtl/index.md
@@ -9,10 +9,8 @@ section: "firrtl"
 We host only the latest minor version for each major version to keep the size down for website hosting.
 Please see the page about [Versioning](../../chisel3/docs/appendix/versioning.html) for more information about major and minor versioning and binary compatibility.
 
-* [1.5.3](1.5.3/)
-* [1.4.4](1.4.4/)
-* [1.3.3](1.3.3/)
-* [1.2.8](1.2.8/)
-* [1.1.7](1.1.7/)
-* [1.0.2](1.0.2/)
+* [1.5](1.5/)
+* [1.4](1.4/)
+* [1.3](1.3/)
+* [1.2](1.2/)
 

--- a/docs/src/main/tut/api/firrtl/latest/index.md
+++ b/docs/src/main/tut/api/firrtl/latest/index.md
@@ -1,0 +1,4 @@
+---
+redirect_to: https://javadoc.io/doc/edu.berkeley.cs/firrtl_2.13
+---
+

--- a/docs/src/main/tut/api/index.md
+++ b/docs/src/main/tut/api/index.md
@@ -9,10 +9,8 @@ section: "chisel3"
 We host only the latest minor version for each major version to keep the size down for website hosting.
 Please see the page about [Versioning](../chisel3/docs/appendix/versioning.html) for more information about major and minor versioning and binary compatibility.
 
-* [3.5.3](3.5.3/)
-* [3.4.4](3.4.4/)
-* [3.3.3](3.3.3/)
-* [3.2.8](3.2.8/)
-* [3.1.8](3.1.8/)
-* [3.0.2](3.0.2/)
+* [3.5](3.5/)
+* [3.4](3.4.4/)
+* [3.3](3.3.3/)
+* [3.2](3.2.8/)
 

--- a/docs/src/main/tut/api/treadle/1.1/index.md
+++ b/docs/src/main/tut/api/treadle/1.1/index.md
@@ -1,0 +1,4 @@
+---
+redirect_to: https://javadoc.io/doc/edu.berkeley.cs/treadle_2.12/1.1
+---
+

--- a/docs/src/main/tut/api/treadle/1.2/index.md
+++ b/docs/src/main/tut/api/treadle/1.2/index.md
@@ -1,0 +1,4 @@
+---
+redirect_to: https://javadoc.io/doc/edu.berkeley.cs/treadle_2.12/1.2
+---
+

--- a/docs/src/main/tut/api/treadle/1.3/index.md
+++ b/docs/src/main/tut/api/treadle/1.3/index.md
@@ -1,0 +1,4 @@
+---
+redirect_to: https://javadoc.io/doc/edu.berkeley.cs/treadle_2.12/1.3
+---
+

--- a/docs/src/main/tut/api/treadle/1.5/index.md
+++ b/docs/src/main/tut/api/treadle/1.5/index.md
@@ -1,0 +1,4 @@
+---
+redirect_to: https://javadoc.io/doc/edu.berkeley.cs/treadle_2.13/1.5
+---
+

--- a/docs/src/main/tut/api/treadle/index.md
+++ b/docs/src/main/tut/api/treadle/index.md
@@ -9,9 +9,8 @@ section: "treadle"
 We host only the latest minor version for each major version to keep the size down for website hosting.
 Please see the page about [Versioning](../../chisel3/docs/appendix/versioning.html) for more information about major and minor versioning and binary compatibility.
 
-* [1.5.3](1.5.3/)
-* [1.3.4](1.3.4/)
-* [1.2.3](1.2.3/)
-* [1.1.8](1.1.8/)
-* [1.0.5](1.0.5/)
+* [1.5](1.5/)
+* [1.3](1.3/)
+* [1.2](1.2/)
+* [1.1](1.1/)
 

--- a/docs/src/main/tut/api/treadle/latest/index.md
+++ b/docs/src/main/tut/api/treadle/latest/index.md
@@ -1,0 +1,4 @@
+---
+redirect_to: https://javadoc.io/doc/edu.berkeley.cs/treadle_2.13
+---
+


### PR DESCRIPTION
Excluding Chisel version 3.2 through 3.4 where the ScalaDoc included in the public jars is not the unidoc and thus is split between the subprojects. We still host the unidoc for the latest of those major versions.

This vastly reduces the amount of things that the website needs to build and host. It also no longer requires any updates to the website to link to newest ScalaDoc for minor releases (still needed for major releases).

The only minor downsides are that 1) it takes slightly longer to redirect to javadoc io than to link to self-hosted api docs, but it's like ~1 second and 2) if javadoc were to have problems, our API docs would be down.

Despite these minor downsides, I think the vast simplification is worth it.