### PR TITLE
Restore link to old /api/latest

### DIFF
--- a/docs/src/main/tut/api/latest/index.md
+++ b/docs/src/main/tut/api/latest/index.md
@@ -1,0 +1,3 @@
+---
+redirect_to: /api/chisel3/latest
+---


### PR DESCRIPTION
I had this bookmarked, others presumably do as well.